### PR TITLE
Update CCI to be string array

### DIFF
--- a/controls/V-72845.rb
+++ b/controls/V-72845.rb
@@ -55,7 +55,7 @@ uri: http://iase.disa.mil
   tag "gid": "V-72845"
   tag "rid": "SV-87497r1_rule"
   tag "stig_id": "PGS9-00-000300"
-  tag "cci": "CCI-002605"
+  tag "cci": ["CCI-002605"]
   tag "nist": ["SI-2 c", "Rev_4"]
 
   tag "check": "If new packages are available for PostgreSQL, they can be

--- a/controls/V-72849.rb
+++ b/controls/V-72849.rb
@@ -53,7 +53,7 @@ control "V-72849" do
   tag "gid": "V-72849"
   tag "rid": "SV-87501r1_rule"
   tag "stig_id": "PGS9-00-000500"
-  tag "cci": "CCI-000015"
+  tag "cci": ["CCI-000015"]
   tag "nist": ["AC-2 (1)", "Rev_4"]
 
   tag "check": "Note: The following instructions use the PGDATA environment

--- a/controls/V-72851.rb
+++ b/controls/V-72851.rb
@@ -86,7 +86,7 @@ control "V-72851" do
   tag "gid": "V-72851"
   tag "rid": "SV-87503r1_rule"
   tag "stig_id": "PGS9-00-000600"
-  tag "cci": "CCI-001312"
+  tag "cci": ["CCI-001312"]
   tag "nist": ["SI-11 a", "Rev_4"]
   tag "check": "As the database administrator, run the following SQL:
 

--- a/controls/V-72857.rb
+++ b/controls/V-72857.rb
@@ -49,7 +49,7 @@ control "V-72857" do
   tag "gid": "V-72857"
   tag "rid": "SV-87509r1_rule"
   tag "stig_id": "PGS9-00-000800"
-  tag "cci": "CCI-000197"
+  tag "cci": ["CCI-000197"]
   tag "nist": ["IA-5 (1) (c)", "Rev_4"]
   tag "check": "Note: The following instructions use the PGDATA environment
   variable. See supplementary content APPENDIX-F for instructions on configuring

--- a/controls/V-72859.rb
+++ b/controls/V-72859.rb
@@ -104,7 +104,7 @@ control "V-72859" do
   tag "gid": "V-72859"
   tag "rid": "SV-87511r1_rule"
   tag "stig_id": "PGS9-00-000900"
-  tag "cci": "CCI-000213"
+  tag "cci": ["CCI-000213"]
   tag "nist": ["AC-3", "Rev_4"]
   tag "check": "From the system security plan or equivalent documentation,
   determine the appropriate permissions on database objects for each kind

--- a/controls/V-72861.rb
+++ b/controls/V-72861.rb
@@ -45,7 +45,7 @@ transmission."
   tag "gid": "V-72861"
   tag "rid": "SV-87513r1_rule"
   tag "stig_id": "PGS9-00-001100"
-  tag "cci": "CCI-002264"
+  tag "cci": ["CCI-002264"]
   tag "nist": ["AC-16 a", "Rev_4"]
   tag "check": "If security labeling is not required, this is not a finding.
   First, as the database administrator (shown here as \"postgres\"), run the

--- a/controls/V-72863.rb
+++ b/controls/V-72863.rb
@@ -77,7 +77,7 @@ control "V-72863" do
   tag "gid": "V-72863"
   tag "rid": "SV-87515r1_rule"
   tag "stig_id": "PGS9-00-001200"
-  tag "cci": "CCI-000054"
+  tag "cci": ["CCI-000054"]
   tag "nist": ["AC-10", "Rev_4"]
   tag "check": 'To check the total amount of connections allowed by the database,
                 as the database administrator, run the following SQL:

--- a/controls/V-72865.rb
+++ b/controls/V-72865.rb
@@ -82,7 +82,7 @@ control "V-72865" do
     tag "gid": "V-72865"
     tag "rid": "SV-87517r1_rule"
     tag "stig_id": "PGS9-00-001300"
-    tag "cci": "CCI-001499"
+    tag "cci": ["CCI-001499"]
     tag "nist": ["CM-5 (6)", "Rev_4"]
     tag "check": "Note: The following instructions use the PGDATA environment
                   variable. See supplementary content APPENDIX-F for instructions

--- a/controls/V-72867.rb
+++ b/controls/V-72867.rb
@@ -68,7 +68,7 @@ control "V-72867" do
   tag "gid": "V-72867"
   tag "rid": "SV-87519r1_rule"
   tag "stig_id": "PGS9-00-001400"
-  tag "cci": "CCI-000804"
+  tag "cci": ["CCI-000804"]
   tag "nist": ["IA-8", "Rev_4"]
   tag "check": "PostgreSQL uniquely identifies and authenticates PostgreSQL
   users through the use of DBMS roles.

--- a/controls/V-72869.rb
+++ b/controls/V-72869.rb
@@ -44,7 +44,7 @@ control "V-72869" do
   tag "gid": "V-72869"
   tag "rid": "SV-87521r1_rule"
   tag "stig_id": "PGS9-00-001700"
-  tag "cci": "CCI-002262"
+  tag "cci": ["CCI-002262"]
   tag "nist": ["AC-16 a", "Rev_4"]
   tag "check": "If security labeling is not required, this is not a finding.
   First, as the database administrator (shown here as \"postgres\"), run the

--- a/controls/V-72871.rb
+++ b/controls/V-72871.rb
@@ -54,7 +54,7 @@ control "V-72871" do
   tag "gid": "V-72871"
   tag "rid": "SV-87523r1_rule"
   tag "stig_id": "PGS9-00-001800"
-  tag "cci": "CCI-001310"
+  tag "cci": ["CCI-001310"]
   tag "nist": ["SI-10", "Rev_4"]
   tag "check": "Review PostgreSQL code (trigger procedures, functions),
   application code, settings, column and field definitions, and constraints to

--- a/controls/V-72873.rb
+++ b/controls/V-72873.rb
@@ -53,7 +53,7 @@ control "V-72873" do
   tag "gid": "V-72873"
   tag "rid": "SV-87525r1_rule"
   tag "stig_id": "PGS9-00-001900"
-  tag "cci": "CCI-001310"
+  tag "cci": ["CCI-001310"]
   tag "nist": ["SI-10", "Rev_4"]
   tag "check": "Review PostgreSQL source code (trigger procedures, functions)
   and application source code, to identify cases of dynamic code execution. Any

--- a/controls/V-72875.rb
+++ b/controls/V-72875.rb
@@ -79,7 +79,7 @@ control "V-72875" do
   tag "gid": "V-72875"
   tag "rid": "SV-87527r1_rule"
   tag "stig_id": "PGS9-00-002000"
-  tag "cci": "CCI-001310"
+  tag "cci": ["CCI-001310"]
   tag "nist": ["SI-10", "Rev_4"]
   tag "check": "Review PostgreSQL source code (trigger procedures, functions)
   and application source code to identify cases of dynamic code execution.

--- a/controls/V-72877.rb
+++ b/controls/V-72877.rb
@@ -47,7 +47,7 @@ control "V-72877" do
   tag "gid": "V-72877"
   tag "rid": "SV-87529r1_rule"
   tag "stig_id": "PGS9-00-002100"
-  tag "cci": "CCI-001849"
+  tag "cci": ["CCI-001849"]
   tag "nist": ["AU-4", "Rev_4"]
   tag "check": "Investigate whether there have been any incidents where
   PostgreSQL ran out of audit log space since the last time the space was

--- a/controls/V-72883.rb
+++ b/controls/V-72883.rb
@@ -83,7 +83,7 @@ control "V-72883" do
   tag "gid": "V-72883"
   tag "rid": "SV-87535r1_rule"
   tag "stig_id": "PGS9-00-002200"
-  tag "cci": "CCI-002165"
+  tag "cci": ["CCI-002165"]
   tag "nist": ["AC-3 (4)", "Rev_4"]
   tag "check": "Review system documentation to identify the required
   discretionary access control (DAC).

--- a/controls/V-72887.rb
+++ b/controls/V-72887.rb
@@ -58,7 +58,7 @@ control "V-72887" do
   tag "gid": "V-72887"
   tag "rid": "SV-87539r1_rule"
   tag "stig_id": "PGS9-00-002400"
-  tag "cci": "CCI-001890"
+  tag "cci": ["CCI-001890"]
   tag "nist": ["AU-8 b", "Rev_4"]
   tag "check": "Note: The following instructions use the PGDATA environment
   variable. See supplementary content APPENDIX-F for instructions on configuring

--- a/controls/V-72891.rb
+++ b/controls/V-72891.rb
@@ -74,7 +74,7 @@ control "V-72891" do
   tag "gid": "V-72891"
   tag "rid": "SV-87543r1_rule"
   tag "stig_id": "PGS9-00-002600"
-  tag "cci": "CCI-000171"
+  tag "cci": ["CCI-000171"]
   tag "nist": ["AU-12 b", "Rev_4"]
   tag "check": "Note: The following instructions use the PGDATA environment
   variable. See supplementary content APPENDIX-F for instructions on configuring

--- a/controls/V-72893.rb
+++ b/controls/V-72893.rb
@@ -40,7 +40,7 @@ control "V-72893" do
   tag "gid": "V-72893"
   tag "rid": "SV-87545r1_rule"
   tag "stig_id": "PGS9-00-002700"
-  tag "cci": "CCI-001858"
+  tag "cci": ["CCI-001858"]
   tag "nist": ["AU-5 (2)", "Rev_4"]
   tag "check": "Review the system documentation to determine which audit failure
   events require real-time alerts.

--- a/controls/V-72895.rb
+++ b/controls/V-72895.rb
@@ -63,7 +63,7 @@ control "V-72895" do
   tag "gid": "V-72895"
   tag "rid": "SV-87547r1_rule"
   tag "stig_id": "PGS9-00-003000"
-  tag "cci": "CCI-002422"
+  tag "cci": ["CCI-002422"]
   tag "nist": ["SC-8 (2)", "Rev_4"]
   tag "check": "If the data owner does not have a strict requirement for
   ensuring data integrity and confidentiality is maintained at every step of the

--- a/controls/V-72897.rb
+++ b/controls/V-72897.rb
@@ -68,7 +68,7 @@ control "V-72897" do
   tag "gid": "V-72897"
   tag "rid": "SV-87549r1_rule"
   tag "stig_id": "PGS9-00-003100"
-  tag "cci": "CCI-001499"
+  tag "cci": ["CCI-001499"]
   tag "nist": ["CM-5 (6)", "Rev_4"]
   tag "check": "Review system documentation to identify accounts authorized to
   own database objects. Review accounts that own objects in the database(s).

--- a/controls/V-72899.rb
+++ b/controls/V-72899.rb
@@ -43,7 +43,7 @@ control "V-72899" do
   tag "gid": "V-72899"
   tag "rid": "SV-87551r1_rule"
   tag "stig_id": "PGS9-00-003200"
-  tag "cci": "CCI-001499"
+  tag "cci": ["CCI-001499"]
   tag "nist": ["CM-5 (6)", "Rev_4"]
   tag "check": "Review procedures for controlling, granting access to, and
   tracking use of the PostgreSQL software installation account(s).

--- a/controls/V-72901.rb
+++ b/controls/V-72901.rb
@@ -54,7 +54,7 @@ control "V-72901" do
   tag "gid": "V-72901"
   tag "rid": "SV-87553r1_rule"
   tag "stig_id": "PGS9-00-003300"
-  tag "cci": "CCI-001499"
+  tag "cci": ["CCI-001499"]
   tag "nist": ["CM-5 (6)", "Rev_4"]
   tag "check": "Review the PostgreSQL software library directory and any
   subdirectories.

--- a/controls/V-72903.rb
+++ b/controls/V-72903.rb
@@ -49,7 +49,7 @@ control "V-72903" do
   tag "gid": "V-72903"
   tag "rid": "SV-87555r1_rule"
   tag "stig_id": "PGS9-00-003500"
-  tag "cci": "CCI-000135"
+  tag "cci": ["CCI-000135"]
   tag "nist": ["AU-3 (1)", "Rev_4"]
   tag "check": "Review the system documentation to identify what additional
   information the organization has determined necessary.

--- a/controls/V-72905.rb
+++ b/controls/V-72905.rb
@@ -66,7 +66,7 @@ control "V-72905" do
   tag "gid": "V-72905"
   tag "rid": "SV-87557r1_rule"
   tag "stig_id": "PGS9-00-003600"
-  tag "cci": "CCI-002233"
+  tag "cci": ["CCI-002233"]
   tag "nist": ["AC-6 (8)", "Rev_4"]
   tag "check": "Functions in PostgreSQL can be created with the SECURITY
   DEFINER option. When SECURITY DEFINER functions are executed by a user, said

--- a/controls/V-72909.rb
+++ b/controls/V-72909.rb
@@ -60,7 +60,7 @@ control "V-72909" do
   tag "gid": "V-72909"
   tag "rid": "SV-87561r1_rule"
   tag "stig_id": "PGS9-00-003800"
-  tag "cci": "CCI-001844"
+  tag "cci": ["CCI-001844"]
   tag "nist": ["AU-3 (2)", "Rev_4"]
   tag "check": "On UNIX systems, PostgreSQL can be configured to use stderr,
   csvlog and syslog. To send logs to a centralized location, syslog should be

--- a/controls/V-72911.rb
+++ b/controls/V-72911.rb
@@ -90,7 +90,7 @@ control "V-72911" do
   tag "gid": "V-72911"
   tag "rid": "SV-87563r1_rule"
   tag "stig_id": "PGS9-00-004000"
-  tag "cci": "CCI-001084"
+  tag "cci": ["CCI-001084"]
   tag "nist": ["SC-3", "Rev_4"]
   tag "check": "Check PostgreSQL settings to determine whether objects or code
   implementing security functionality are located in a separate security domain,

--- a/controls/V-72917.rb
+++ b/controls/V-72917.rb
@@ -39,7 +39,7 @@ control "V-72917" do
   tag "gid": "V-72917"
   tag "rid": "SV-87569r1_rule"
   tag "stig_id": "PGS9-00-004300"
-  tag "cci": "CCI-002617"
+  tag "cci": ["CCI-002617"]
   tag "nist": ["SI-2 (6)", "Rev_4"]
   tag "check": "To check software installed by packages, as the system
   administrator, run the following command:

--- a/controls/V-72919.rb
+++ b/controls/V-72919.rb
@@ -54,7 +54,7 @@ control "V-72919" do
   tag "gid": "V-72919"
   tag "rid": "SV-87571r1_rule"
   tag "stig_id": "PGS9-00-004400"
-  tag "cci": "CCI-000172"
+  tag "cci": ["CCI-000172"]
   tag "nist": ["AU-12 c", "Rev_4"]
   tag "check": "As the database administrator (shown here as \"postgres\"), run
   the following SQL:

--- a/controls/V-72931.rb
+++ b/controls/V-72931.rb
@@ -57,7 +57,7 @@ control "V-72931" do
   tag "gid": "V-72931"
   tag "rid": "SV-87583r1_rule"
   tag "stig_id": "PGS9-00-005000"
-  tag "cci": "CCI-000172"
+  tag "cci": ["CCI-000172"]
   tag "nist": ["AU-12 c", "Rev_4"]
   tag "check": "First, as the database administrator, verify pgaudit is enabled
   by running the following SQL:

--- a/controls/V-72949.rb
+++ b/controls/V-72949.rb
@@ -57,7 +57,7 @@ control "V-72949" do
   tag "gid": "V-72949"
   tag "rid": "SV-87601r1_rule"
   tag "stig_id": "PGS9-00-005600"
-  tag "cci": "CCI-000172"
+  tag "cci": ["CCI-000172"]
   tag "nist": ["AU-12 c", "Rev_4"]
   tag "check": "First, as the database administrator, verify pgaudit is enabled
   by running the following SQL:

--- a/controls/V-72953.rb
+++ b/controls/V-72953.rb
@@ -78,7 +78,7 @@ control "V-72953" do
   tag "gid": "V-72953"
   tag "rid": "SV-87605r1_rule"
   tag "stig_id": "PGS9-00-005800"
-  tag "cci": "CCI-000172"
+  tag "cci": ["CCI-000172"]
   tag "nist": ["AU-12 c", "Rev_4"]
   tag "check": "First, as the database administrator, verify pgaudit is enabled
   by running the following SQL:

--- a/controls/V-72955.rb
+++ b/controls/V-72955.rb
@@ -57,7 +57,7 @@ control "V-72955" do
   tag "gid": "V-72955"
   tag "rid": "SV-87607r1_rule"
   tag "stig_id": "PGS9-00-005900"
-  tag "cci": "CCI-000172"
+  tag "cci": ["CCI-000172"]
   tag "nist": ["AU-12 c", "Rev_4"]
   tag "check": "First, as the database administrator (shown here as
   \"postgres\"), run the following SQL:

--- a/controls/V-72957.rb
+++ b/controls/V-72957.rb
@@ -63,7 +63,7 @@ control "V-72957" do
   tag "gid": "V-72957"
   tag "rid": "SV-87609r1_rule"
   tag "stig_id": "PGS9-00-006000"
-  tag "cci": "CCI-000172"
+  tag "cci": ["CCI-000172"]
   tag "nist": ["AU-12 c", "Rev_4"]
   tag "check": "First, as the database administrator, verify pgaudit is enabled
   by running the following SQL:

--- a/controls/V-72959.rb
+++ b/controls/V-72959.rb
@@ -55,7 +55,7 @@ control "V-72959" do
   tag "gid": "V-72959"
   tag "rid": "SV-87611r1_rule"
   tag "stig_id": "PGS9-00-006100"
-  tag "cci": "CCI-000172"
+  tag "cci": ["CCI-000172"]
   tag "nist": ["AU-12 c", "Rev_4"]
   tag "check": "First, as the database administrator, verify pgaudit is enabled
   by running the following SQL:

--- a/controls/V-72961.rb
+++ b/controls/V-72961.rb
@@ -59,7 +59,7 @@ control "V-72961" do
   tag "gid": "V-72961"
   tag "rid": "SV-87613r1_rule"
   tag "stig_id": "PGS9-00-006200"
-  tag "cci": "CCI-000172"
+  tag "cci": ["CCI-000172"]
   tag "nist": ["AU-12 c", "Rev_4"]
   tag "check": "First, as the database administrator, verify that
   log_connections and log_disconnections are enabled by running the following

--- a/controls/V-72963.rb
+++ b/controls/V-72963.rb
@@ -53,7 +53,7 @@ control "V-72963" do
   tag "gid": "V-72963"
   tag "rid": "SV-87615r1_rule"
   tag "stig_id": "PGS9-00-006300"
-  tag "cci": "CCI-000172"
+  tag "cci": ["CCI-000172"]
   tag "nist": ["AU-12 c", "Rev_4"]
   tag "check": "Note: The following instructions use the PGDATA environment
   variable. See supplementary content APPENDIX-F for instructions on configuring

--- a/controls/V-72965.rb
+++ b/controls/V-72965.rb
@@ -55,7 +55,7 @@ control "V-72965" do
   tag "gid": "V-72965"
   tag "rid": "SV-87617r1_rule"
   tag "stig_id": "PGS9-00-006400"
-  tag "cci": "CCI-000172"
+  tag "cci": ["CCI-000172"]
   tag "nist": ["AU-12 c", "Rev_4"]
   tag "check": "First, as the database administrator, verify pgaudit is enabled
   by running the following SQL:

--- a/controls/V-72971.rb
+++ b/controls/V-72971.rb
@@ -53,7 +53,7 @@ control "V-72971" do
   tag "gid": "V-72971"
   tag "rid": "SV-87623r1_rule"
   tag "stig_id": "PGS9-00-006600"
-  tag "cci": "CCI-000172"
+  tag "cci": ["CCI-000172"]
   tag "nist": ["AU-12 c", "Rev_4"]
   tag "check": "First, as the database administrator, verify pgaudit is enabled
   by running the following SQL:

--- a/controls/V-72973.rb
+++ b/controls/V-72973.rb
@@ -54,7 +54,7 @@ PG_HOST = attribute(
   tag "gid": "V-72973"
   tag "rid": "SV-87625r1_rule"
   tag "stig_id": "PGS9-00-006700"
-  tag "cci": "CCI-000172"
+  tag "cci": ["CCI-000172"]
   tag "nist": ["AU-12 c", "Rev_4"]
   tag "check": "If category tracking is not required in the database, this is
   not applicable.

--- a/controls/V-72979.rb
+++ b/controls/V-72979.rb
@@ -72,7 +72,7 @@ control "V-72979" do
   tag "gid": "V-72979"
   tag "rid": "SV-87631r1_rule"
   tag "stig_id": "PGS9-00-007000"
-  tag "cci": "CCI-000185"
+  tag "cci": ["CCI-000185"]
   tag "nist": ["IA-5 (2) (a)", "Rev_4"]
   tag "check": "Note: The following instructions use the PGDATA environment
   variable. See supplementary content APPENDIX-F for instructions on configuring

--- a/controls/V-72981.rb
+++ b/controls/V-72981.rb
@@ -61,7 +61,7 @@ control "V-72981" do
   tag "gid": "V-72981"
   tag "rid": "SV-87633r1_rule"
   tag "stig_id": "PGS9-00-007200"
-  tag "cci": "CCI-002420"
+  tag "cci": ["CCI-002420"]
   tag "nist": ["SC-8 (2)", "Rev_4"]
   tag "check": "If the data owner does not have a strict requirement for ensuring
   data integrity and confidentiality is maintained at every step of the data

--- a/controls/V-72983.rb
+++ b/controls/V-72983.rb
@@ -50,7 +50,7 @@ control "V-72983" do
   tag "gid": "V-72983"
   tag "rid": "SV-87635r1_rule"
   tag "stig_id": "PGS9-00-007400"
-  tag "cci": "CCI-000169"
+  tag "cci": ["CCI-000169"]
   tag "nist": ["AU-12 a", "Rev_4"]
   tag "check": "Check PostgreSQL auditing to determine whether
   organization-defined auditable events are being audited by the system.

--- a/controls/V-72989.rb
+++ b/controls/V-72989.rb
@@ -37,7 +37,7 @@ control "V-72989" do
   tag "gid": "V-72989"
   tag "rid": "SV-87641r1_rule"
   tag "stig_id": "PGS9-00-008000"
-  tag "cci": "CCI-002450"
+  tag "cci": ["CCI-002450"]
   tag "nist": ["SC-13", "Rev_4"]
 
   tag "check": "First, as the system administrator, run the following to see if FIPS

--- a/controls/V-72991.rb
+++ b/controls/V-72991.rb
@@ -60,7 +60,7 @@ requirement addresses the compatibility of PostgreSQL with the encryption device
   tag "gid": "V-72991"
   tag "rid": "SV-87643r1_rule"
   tag "stig_id": "PGS9-00-008100"
-  tag "cci": "CCI-002450"
+  tag "cci": ["CCI-002450"]
   tag "nist": ["SC-13", "Rev_4"]
 
   tag "check": "If PostgreSQL is deployed in an unclassified environment, this is

--- a/controls/V-72993.rb
+++ b/controls/V-72993.rb
@@ -47,7 +47,7 @@ modules must be validated and certified by NIST as FIPS-compliant."
   tag "gid": "V-72993"
   tag "rid": "SV-87645r1_rule"
   tag "stig_id": "PGS9-00-008200"
-  tag "cci": "CCI-002450"
+  tag "cci": ["CCI-002450"]
   tag "nist": ["SC-13", "Rev_4"]
 
   tag "check": "First, as the system administrator, run the following to see if FIPS

--- a/controls/V-72995.rb
+++ b/controls/V-72995.rb
@@ -63,7 +63,7 @@ will be open to compromise and unauthorized modification."
   tag "gid": "V-72995"
   tag "rid": "SV-87647r1_rule"
   tag "stig_id": "PGS9-00-008300"
-  tag "cci": "CCI-001199"
+  tag "cci": ["CCI-001199"]
   tag "nist": ["SC-28", "Rev_4"]
 
   tag "check": "One possible way to encrypt data within PostgreSQL is to use the

--- a/controls/V-72999.rb
+++ b/controls/V-72999.rb
@@ -80,7 +80,7 @@ inadvertently made available to the user."
   tag "gid": "V-72999"
   tag "rid": "SV-87651r1_rule"
   tag "stig_id": "PGS9-00-008500"
-  tag "cci": "CCI-001082"
+  tag "cci": ["CCI-001082"]
   tag "nist": ["SC-2", "Rev_4"]
 
   tag "check": "Check PostgreSQL settings and vendor documentation to verify that

--- a/controls/V-73001.rb
+++ b/controls/V-73001.rb
@@ -51,7 +51,7 @@ control "V-73001" do
   tag "gid": "V-73001"
   tag "rid": "SV-87653r1_rule"
   tag "stig_id": "PGS9-00-008600"
-  tag "cci": "CCI-001464"
+  tag "cci": ["CCI-001464"]
   tag "nist": ["AU-14 (1)", "Rev_4"]
 
   tag "check": "As the database administrator (shown here as \"postgres\"), check

--- a/controls/V-73003.rb
+++ b/controls/V-73003.rb
@@ -66,7 +66,7 @@ the information resides."
   tag "gid": "V-73003"
   tag "rid": "SV-87655r1_rule"
   tag "stig_id": "PGS9-00-008700"
-  tag "cci": "CCI-002475"
+  tag "cci": ["CCI-002475"]
   tag "nist": ["SC-28 (1)", "Rev_4"]
 
   tag "check": "Review the system documentation to determine whether the

--- a/controls/V-73005.rb
+++ b/controls/V-73005.rb
@@ -65,7 +65,7 @@ capacity thresholds; or identifying an improperly configured application."
   tag "gid": "V-73005"
   tag "rid": "SV-87657r1_rule"
   tag "stig_id": "PGS9-00-008800"
-  tag "cci": "CCI-000133"
+  tag "cci": ["CCI-000133"]
   tag "nist": ["AU-3", "Rev_4"]
 
   tag "check": "Check PostgreSQL settings and existing audit records to verify

--- a/controls/V-73011.rb
+++ b/controls/V-73011.rb
@@ -48,7 +48,7 @@ permissions."
   tag "gid": "V-73011"
   tag "rid": "SV-87663r1_rule"
   tag "stig_id": "PGS9-00-009200"
-  tag "cci": "CCI-000381"
+  tag "cci": ["CCI-000381"]
   tag "nist": ["CM-7 a", "Rev_4"]
   tag "check": "To list all installed packages, as the system administrator, run the
 following:

--- a/controls/V-73013.rb
+++ b/controls/V-73013.rb
@@ -49,7 +49,7 @@ PostgreSQL, a third-party product, or custom application code."
   tag "gid": "V-73013"
   tag "rid": "SV-87665r1_rule"
   tag "stig_id": "PGS9-00-009400"
-  tag "cci": "CCI-002263"
+  tag "cci": ["CCI-002263"]
   tag "nist": ["AC-16 a", "Rev_4"]
   tag "check": "If security labeling is not required, this is not a finding.
 

--- a/controls/V-73015.rb
+++ b/controls/V-73015.rb
@@ -57,7 +57,7 @@ internally or externally to PostgreSQL."
   tag "gid": "V-73015"
   tag "rid": "SV-87667r1_rule"
   tag "stig_id": "PGS9-00-009500"
-  tag "cci": "CCI-000196"
+  tag "cci": ["CCI-000196"]
   tag "nist": ["IA-5 (1) (c)", "Rev_4"]
   tag "check": "To check if password encryption is enabled, as the database
 administrator (shown here as \"postgres\"), run the following SQL:

--- a/controls/V-73017.rb
+++ b/controls/V-73017.rb
@@ -69,7 +69,7 @@ upgrades and modifications."
   tag "gid": "V-73017"
   tag "rid": "SV-87669r1_rule"
   tag "stig_id": "PGS9-00-009600"
-  tag "cci": "CCI-001813"
+  tag "cci": ["CCI-001813"]
   tag "nist": ["CM-5 (1)", "Rev_4"]
   tag "check": "To list all the permissions of individual roles, as the database
 administrator (shown here as \"postgres\"), run the following SQL:

--- a/controls/V-73019.rb
+++ b/controls/V-73019.rb
@@ -63,7 +63,7 @@ a standard, shared account."
   tag "gid": "V-73019"
   tag "rid": "SV-87671r1_rule"
   tag "stig_id": "PGS9-00-009700"
-  tag "cci": "CCI-000166"
+  tag "cci": ["CCI-000166"]
   tag "nist": ["AU-10", "Rev_4"]
   tag "check": "First, as the database administrator, review the current
 log_line_prefix settings by running the following SQL:

--- a/controls/V-73021.rb
+++ b/controls/V-73021.rb
@@ -55,7 +55,7 @@ requirement, however, deals specifically with PostgreSQL."
   tag "gid": "V-73021"
   tag "rid": "SV-87673r1_rule"
   tag "stig_id": "PGS9-00-009800"
-  tag "cci": "CCI-001462"
+  tag "cci": ["CCI-001462"]
   tag "nist": ["AU-14 (2)", "Rev_4"]
   tag "check": "First, as the database administrator (shown here as \"postgres\"),
 verify pgaudit is installed by running the following SQL:

--- a/controls/V-73023.rb
+++ b/controls/V-73023.rb
@@ -41,7 +41,7 @@ The appropriate support staff include, at a minimum, the ISSO and the DBA/SA."
   tag "gid": "V-73023"
   tag "rid": "SV-87675r1_rule"
   tag "stig_id": "PGS9-00-009900"
-  tag "cci": "CCI-001855"
+  tag "cci": ["CCI-001855"]
   tag "nist": ["AU-5 (1)", "Rev_4"]
   tag "check": "Review system configuration.
 

--- a/controls/V-73025.rb
+++ b/controls/V-73025.rb
@@ -59,7 +59,7 @@ actions are changed, for example, near real time, within minutes, or within hour
   tag "gid": "V-73025"
   tag "rid": "SV-87677r1_rule"
   tag "stig_id": "PGS9-00-010000"
-  tag "cci": "CCI-001914"
+  tag "cci": ["CCI-001914"]
   tag "nist": ["AU-12 (3)", "Rev_4"]
   tag "check": "First, as the database administrator, check if pgaudit is present in
 shared_preload_libraries:

--- a/controls/V-73027.rb
+++ b/controls/V-73027.rb
@@ -54,7 +54,7 @@ escalation and role changes."
   tag "gid": "V-73027"
   tag "rid": "SV-87679r1_rule"
   tag "stig_id": "PGS9-00-010100"
-  tag "cci": "CCI-002038"
+  tag "cci": ["CCI-002038"]
   tag "nist": ["IA-11", "Rev_4"]
   tag "check": "Determine all situations where a user must re-authenticate. Check if
 the mechanisms that handle such situations use the following SQL:

--- a/controls/V-73029.rb
+++ b/controls/V-73029.rb
@@ -77,7 +77,7 @@ actions."
   tag "gid": "V-73029"
   tag "rid": "SV-87681r1_rule"
   tag "stig_id": "PGS9-00-010200"
-  tag "cci": "CCI-000186"
+  tag "cci": ["CCI-000186"]
   tag "nist": ["IA-5 (2) (b)", "Rev_4"]
   tag "check": "First, as the database administrator (shown here as \"postgres\"),
 verify the following settings:

--- a/controls/V-73031.rb
+++ b/controls/V-73031.rb
@@ -60,7 +60,7 @@ than for the network packet."
   tag "gid": "V-73031"
   tag "rid": "SV-87683r1_rule"
   tag "stig_id": "PGS9-00-010300"
-  tag "cci": "CCI-002470"
+  tag "cci": ["CCI-002470"]
   tag "nist": ["SC-23 (5)", "Rev_4"]
   tag "check": "As the database administrator (shown here as \"postgres\"), verify
 the following setting in postgresql.conf:

--- a/controls/V-73033.rb
+++ b/controls/V-73033.rb
@@ -67,7 +67,7 @@ stored with the audit record, the record itself is of very limited use."
   tag "gid": "V-73033"
   tag "rid": "SV-87685r1_rule"
   tag "stig_id": "PGS9-00-010400"
-  tag "cci": "CCI-000130"
+  tag "cci": ["CCI-000130"]
   tag "nist": ["AU-3", "Rev_4"]
   tag "check": "As the database administrator (shown here as \"postgres\"), verify
 the current log_line_prefix setting in postgresql.conf:

--- a/controls/V-73035.rb
+++ b/controls/V-73035.rb
@@ -65,7 +65,7 @@ the information resides."
   tag "gid": "V-73035"
   tag "rid": "SV-87687r1_rule"
   tag "stig_id": "PGS9-00-010500"
-  tag "cci": "CCI-002476"
+  tag "cci": ["CCI-002476"]
   tag "nist": ["SC-28 (1)", "Rev_4"]
   tag "check": "To check if pgcrypto is installed on PostgreSQL, as a database
 administrator (shown here as \"postgres\"), run the following command:

--- a/controls/V-73037.rb
+++ b/controls/V-73037.rb
@@ -70,7 +70,7 @@ hijacked."
   tag "gid": "V-73037"
   tag "rid": "SV-87689r1_rule"
   tag "stig_id": "PGS9-00-010600"
-  tag "cci": "CCI-001185"
+  tag "cci": ["CCI-001185"]
   tag "nist": ["SC-23 (1)", "Rev_4"]
   tag "check": "As the database administrator (shown here as \"postgres\"), run the
 following SQL:

--- a/controls/V-73041.rb
+++ b/controls/V-73041.rb
@@ -64,7 +64,7 @@ record, the record itself is of very limited use."
   tag "gid": "V-73041"
   tag "rid": "SV-87693r1_rule"
   tag "stig_id": "PGS9-00-011100"
-  tag "cci": "CCI-000131"
+  tag "cci": ["CCI-000131"]
   tag "nist": ["AU-3", "Rev_4"]
   tag "check": "As the database administrator (usually postgres, run the following
 SQL:

--- a/controls/V-73045.rb
+++ b/controls/V-73045.rb
@@ -40,7 +40,7 @@ to the centralized system."
   tag "gid": "V-73045"
   tag "rid": "SV-87697r1_rule"
   tag "stig_id": "PGS9-00-011300"
-  tag "cci": "CCI-001851"
+  tag "cci": ["CCI-001851"]
   tag "nist": ["AU-4 (1)", "Rev_4"]
   tag "check": "First, as the database administrator (shown here as \"postgres\"),
 ensure PostgreSQL uses syslog by running the following SQL:

--- a/controls/V-73047.rb
+++ b/controls/V-73047.rb
@@ -59,7 +59,7 @@ effective."
   tag "gid": "V-73047"
   tag "rid": "SV-87699r1_rule"
   tag "stig_id": "PGS9-00-011400"
-  tag "cci": "CCI-001188"
+  tag "cci": ["CCI-001188"]
   tag "nist": ["SC-23 (3)", "Rev_4"]
   tag "check": "To check if PostgreSQL is configured to use ssl, as the database
 administrator (shown here as \"postgres\"), run the following SQL:

--- a/controls/V-73049.rb
+++ b/controls/V-73049.rb
@@ -90,7 +90,7 @@ activity."
   tag "gid": "V-73049"
   tag "rid": "SV-87701r1_rule"
   tag "stig_id": "PGS9-00-011500"
-  tag "cci": "CCI-000764"
+  tag "cci": ["CCI-000764"]
   tag "nist": ["IA-2", "Rev_4"]
   tag "check": "Review PostgreSQL settings to determine whether organizational users
 are uniquely identified and authenticated when logging on/connecting to the system.

--- a/controls/V-73051.rb
+++ b/controls/V-73051.rb
@@ -47,7 +47,7 @@ data owner, or organization requires additional assurance."
   tag "gid": "V-73051"
   tag "rid": "SV-87703r1_rule"
   tag "stig_id": "PGS9-00-011600"
-  tag "cci": "CCI-002361"
+  tag "cci": ["CCI-002361"]
   tag "nist": ["AC-12", "Rev_4"]
   tag "check": "Review system documentation to obtain the organization's definition
 of circumstances requiring automatic session termination. If the documentation

--- a/controls/V-73055.rb
+++ b/controls/V-73055.rb
@@ -33,7 +33,7 @@ authorization decisions."
   tag "gid": "V-73055"
   tag "rid": "SV-87707r1_rule"
   tag "stig_id": "PGS9-00-011800"
-  tag "cci": "CCI-000187"
+  tag "cci": ["CCI-000187"]
   tag "nist": ["IA-5 (2) (c)", "Rev_4"]
   tag "check": "The cn (Common Name) attribute of the certificate will be compared
 to the requested database user name, and if they match the login will be allowed.

--- a/controls/V-73057.rb
+++ b/controls/V-73057.rb
@@ -39,7 +39,7 @@ without the proper controls."
   tag "gid": "V-73057"
   tag "rid": "SV-87709r1_rule"
   tag "stig_id": "PGS9-00-011900"
-  tag "cci": "CCI-001090"
+  tag "cci": ["CCI-001090"]
   tag "nist": ["SC-4", "Rev_4"]
   tag "check": "Review the procedures for the refreshing of development/test data
 from production.

--- a/controls/V-73061.rb
+++ b/controls/V-73061.rb
@@ -72,7 +72,7 @@ control "V-73061" do
   tag "gid": "V-73061"
   tag "rid": "SV-87713r1_rule"
   tag "stig_id": "PGS9-00-012200"
-  tag "cci": "CCI-001494"
+  tag "cci": ["CCI-001494"]
   tag "nist": ["AU-9", "Rev_4"]
 
   tag "check": "All configurations for auditing and logging can be found in the

--- a/controls/V-73063.rb
+++ b/controls/V-73063.rb
@@ -113,7 +113,7 @@ control "V-73063" do
   tag "gid": "V-73063"
   tag "rid": "SV-87715r1_rule"
   tag "stig_id": "PGS9-00-012300"
-  tag "cci": "CCI-000803"
+  tag "cci": ["CCI-000803"]
   tag "nist": ["IA-7", "Rev_4"]
 
   tag "check": "As the system administrator, run the following:

--- a/controls/V-73065.rb
+++ b/controls/V-73065.rb
@@ -56,7 +56,7 @@ control "V-73065" do
   tag "gid": "V-73065"
   tag "rid": "SV-87717r1_rule"
   tag "stig_id": "PGS9-00-012500"
-  tag "cci": "CCI-000172"
+  tag "cci": ["CCI-000172"]
   tag "nist": ["AU-12 c", "Rev_4"]
 
   tag "check": "As the database administrator, verify pgaudit is enabled by running

--- a/controls/V-73067.rb
+++ b/controls/V-73067.rb
@@ -63,7 +63,7 @@ control "V-73067" do
   tag "gid": "V-73067"
   tag "rid": "SV-87719r1_rule"
   tag "stig_id": "PGS9-00-012600"
-  tag "cci": "CCI-000172"
+  tag "cci": ["CCI-000172"]
   tag "nist": ["AU-12 c", "Rev_4"]
 
   tag "check": "As the database administrator, verify pgaudit is enabled by

--- a/controls/V-73069.rb
+++ b/controls/V-73069.rb
@@ -54,7 +54,7 @@ control "V-73069" do
   tag "gid": "V-73069"
   tag "rid": "SV-87721r1_rule"
   tag "stig_id": "PGS9-00-012700"
-  tag "cci": "CCI-000172"
+  tag "cci": ["CCI-000172"]
   tag "nist": ["AU-12 c", "Rev_4"]
 
   tag "check": "As the database administrator, verify pgaudit is enabled by running

--- a/controls/V-73071.rb
+++ b/controls/V-73071.rb
@@ -34,7 +34,7 @@ control "V-73071" do
   tag "gid": "V-73071"
   tag "rid": "SV-87723r1_rule"
   tag "stig_id": "PGS9-00-012800"
-  tag "cci": "CCI-000803"
+  tag "cci": ["CCI-000803"]
   tag "nist": ["IA-7", "Rev_4"]
 
   tag "check": "If the deployment incorporates a custom build of the operating

--- a/controls/V-73123.rb
+++ b/controls/V-73123.rb
@@ -59,7 +59,7 @@ control "V-73123" do
   tag "gid": "V-73123"
   tag "rid": "SV-87775r1_rule"
   tag "stig_id": "PGS9-00-007100"
-  tag "cci": "CCI-000132"
+  tag "cci": ["CCI-000132"]
   tag "nist": ["AU-3", "Rev_4"]
 
   tag "check": "Note: The following instructions use the PGDATA environment variable.


### PR DESCRIPTION
Issue here: #6 

One of the controls has multiple CCIs, which requires a string array.  The rest of the controls are just normal strings.  This makes an inconsistency with the json output and makes it very hard to parse the output in statically typed languages.

This patch changes all CCI to be a string array to avoid inconsistency.