### PR TITLE
Reduce globals and warnings

### DIFF
--- a/controls/V-72841.rb
+++ b/controls/V-72841.rb
@@ -20,27 +20,27 @@ Source: STIG.DOD.MIL
 uri: http://iase.disa.mil
 -----------------
 =end
-PG_DBA = attribute(
+pg_dba = attribute(
   'pg_dba',
   description: 'The postgres DBA user to access the test database',
 )
 
-PG_DBA_PASSWORD = attribute(
+pg_dba_password = attribute(
   'pg_dba_password',
   description: 'The password for the postgres DBA user',
 )
 
-PG_DB = attribute(
+pg_db = attribute(
   'pg_db',
   description: 'The database used for tests',
 )
 
-PG_HOST = attribute(
+pg_host = attribute(
   'pg_host',
   description: 'The hostname or IP address used to connect to the database',
 )
 
-PG_PORT = attribute(
+pg_port = attribute(
   'pg_port',
   description: 'The port used to connect to the database',
 )
@@ -73,7 +73,7 @@ control "V-72841" do
         This can allow unauthorized access to the database and through the
         database to other components of the information system."
   impact 0.5
-  
+
   tag "severity": "medium"
   tag "gtitle": "SRG-APP-000142-DB-000094"
   tag "gid": "V-72841"
@@ -115,13 +115,13 @@ control "V-72841" do
   $ psql -p 5432 -c \"SHOW port\"
   $ export PGPORT=5432"
 
-  sql = postgres_session(PG_DBA, PG_DBA_PASSWORD, PG_HOST)
+  sql = postgres_session(pg_dba, pg_dba_password, pg_host)
 
-  describe sql.query('SHOW port;', [PG_DB]) do
-    its('output') { should eq PG_PORT }
+  describe sql.query('SHOW port;', [pg_db]) do
+    its('output') { should eq pg_port }
   end
 
-  describe port(PG_PORT) do
+  describe port(pg_port) do
     it { should be_listening }
     its('processes') { should include 'postgres' }
   end

--- a/controls/V-72851.rb
+++ b/controls/V-72851.rb
@@ -19,37 +19,37 @@ Source: STIG.DOD.MIL
 uri: http://iase.disa.mil
 -----------------
 =end
-PG_DBA = attribute(
+pg_dba = attribute(
   'pg_dba',
   description: 'The postgres DBA user to access the test database',
 )
 
-PG_DBA_PASSWORD = attribute(
+pg_dba_password = attribute(
   'pg_dba_password',
   description: 'The password for the postgres DBA user',
 )
 
-PG_DB = attribute(
+pg_db = attribute(
   'pg_db',
   description: 'The database used for tests',
 )
 
-PG_HOST = attribute(
+pg_host = attribute(
   'pg_host',
   description: 'The hostname or IP address used to connect to the database',
 )
 
-PG_DATA_DIR = attribute(
+pg_data_dir = attribute(
   'pg_data_dir',
   description: 'The postgres data directory',
 )
 
-PG_CONF_FILE = attribute(
+pg_conf_file = attribute(
   'pg_conf_file',
   description: 'The postgres configuration file',
 )
 
-PG_USER_DEFINED_CONF = attribute(
+pg_user_defined_conf = attribute(
   'pg_user_defined_conf',
   description: 'An additional postgres configuration file used to override default values',
 )
@@ -111,11 +111,11 @@ control "V-72851" do
   # INITD SERVER ONLY
   $ service postgresql-9.5 reload "
 
-  default = postgres_conf(PG_CONF_FILE)
-  override = postgres_conf(PG_USER_DEFINED_CONF)
-  sql = postgres_session(PG_DBA, PG_DBA_PASSWORD, PG_HOST)
+  default = postgres_conf(pg_conf_file)
+  override = postgres_conf(pg_user_defined_conf)
+  sql = postgres_session(pg_dba, pg_dba_password, pg_host)
 
-  describe sql.query('SHOW client_min_messages;', [PG_DB]) do
+  describe sql.query('SHOW client_min_messages;', [pg_db]) do
    its('output') { should match /^error$/i }
   end
 

--- a/controls/V-72857.rb
+++ b/controls/V-72857.rb
@@ -19,12 +19,12 @@ Source: STIG.DOD.MIL
 uri: http://iase.disa.mil
 -----------------
 =end
-PG_DATA_DIR = attribute(
+pg_data_dir = attribute(
   'pg_data_dir',
   description: 'The postgres data directory',
 )
 
-PG_HBA_CONF_FILE = attribute(
+pg_hba_conf_file = attribute(
   'pg_hba_conf_file',
   description: 'The postgres hba configuration file',
 )
@@ -71,7 +71,7 @@ control "V-72857" do
   $ vi ${PGDATA?}/pg_hba.conf
   host all all .example.com md5"
 
-  describe postgres_hba_conf(PG_HBA_CONF_FILE) do
+  describe postgres_hba_conf(pg_hba_conf_file) do
     its('auth_method') { should_not include 'password' }
   end
 end

--- a/controls/V-72859.rb
+++ b/controls/V-72859.rb
@@ -19,47 +19,47 @@ Source: STIG.DOD.MIL
 uri: http://iase.disa.mil
 -----------------
 =end
-PG_OWNER = attribute(
+pg_owner = attribute(
   'pg_owner',
   description: "The system user of the postgres process",
 )
 
-PG_DBA = attribute(
+pg_dba = attribute(
   'pg_dba',
   description: 'The postgres DBA user to access the test database',
 )
 
-PG_DBA_PASSWORD = attribute(
+pg_dba_password = attribute(
   'pg_dba_password',
   description: 'The password for the postgres DBA user',
 )
 
-PG_DB = attribute(
+pg_db = attribute(
   'pg_db',
   description: 'The database used for tests',
 )
 
-PG_HOST = attribute(
+pg_host = attribute(
   'pg_host',
   description: 'The hostname or IP address used to connect to the database',
 )
 
-PG_DATA_DIR = attribute(
+pg_data_dir = attribute(
   'pg_data_dir',
   description: 'The postgres data directory',
 )
 
-PG_SUPERUSERS = attribute(
+pg_superusers = attribute(
   'pg_superusers',
   description: 'Authorized superuser accounts',
 )
 
-PG_HBA_CONF_FILE = attribute(
+pg_hba_conf_file = attribute(
   'pg_hba_conf_file',
   description: 'The postgres hba configuration file',
 )
 
-PG_REPLICAS = attribute(
+pg_replicas = attribute(
   'pg_replicas',
   description: 'List of postgres replicas in CIDR notation',
 )
@@ -243,24 +243,24 @@ https://www.postgresql.org/docs/current/static/sql-grant.html
   # INITD SERVER ONLY
   $ sudo service postgresql-9.5 reload"
 
-  sql = postgres_session(PG_DBA, PG_DBA_PASSWORD, PG_HOST)
+  sql = postgres_session(pg_dba, pg_dba_password, pg_host)
 
   roles_sql = 'SELECT r.rolname FROM pg_catalog.pg_roles r;'
-  roles_query = sql.query(roles_sql, [PG_DB])
+  roles_query = sql.query(roles_sql, [pg_db])
   roles = roles_query.lines
 
   roles.each do |role|
-    unless PG_SUPERUSERS.include?(role)
+    unless pg_superusers.include?(role)
       superuser_sql = "SELECT r.rolsuper FROM pg_catalog.pg_roles r "\
         "WHERE r.rolname = '#{role}';"
 
-      describe sql.query(superuser_sql, [PG_DB]) do
+      describe sql.query(superuser_sql, [pg_db]) do
         its('output') { should_not eq 't' }
       end
     end
   end
 
-  authorized_owners = PG_SUPERUSERS
+  authorized_owners = pg_superusers
   owners = authorized_owners.join('|')
 
   object_granted_privileges = 'arwdDxtU'
@@ -276,7 +276,7 @@ https://www.postgresql.org/docs/current/static/sql-grant.html
     "AND n.nspname !~ '^pg_' AND pg_catalog.pg_table_is_visible(c.oid);"
 
   databases_sql = 'SELECT datname FROM pg_catalog.pg_database where not datistemplate;'
-  databases_query = sql.query(databases_sql, [PG_DB])
+  databases_query = sql.query(databases_sql, [pg_db])
   databases = databases_query.lines
 
   databases.each do |database|
@@ -300,26 +300,26 @@ https://www.postgresql.org/docs/current/static/sql-grant.html
     end
   end
 
-  describe postgres_hba_conf(PG_HBA_CONF_FILE).where { type == 'local' } do
-    its('user.uniq') { should cmp PG_OWNER }
+  describe postgres_hba_conf(pg_hba_conf_file).where { type == 'local' } do
+    its('user.uniq') { should cmp pg_owner }
     its('auth_method.uniq') { should_not cmp 'trust'}
   end
 
   describe.one do
-    describe postgres_hba_conf(PG_HBA_CONF_FILE).where { database == 'replication' } do
+    describe postgres_hba_conf(pg_hba_conf_file).where { database == 'replication' } do
       its('type.uniq') { should cmp 'host' }
-      its('address.uniq.sort') { should cmp PG_REPLICAS.sort }
+      its('address.uniq.sort') { should cmp pg_replicas.sort }
       its('user.uniq') { should cmp 'replication' }
       its('auth_method.uniq') { should cmp 'md5' }
     end
-    describe postgres_hba_conf(PG_HBA_CONF_FILE).where { database == 'replication' } do
+    describe postgres_hba_conf(pg_hba_conf_file).where { database == 'replication' } do
       its('type.uniq') { should cmp 'hostssl' }
-      its('address.uniq.sort') { should cmp PG_REPLICAS.sort }
+      its('address.uniq.sort') { should cmp pg_replicas.sort }
       its('user.uniq') { should cmp 'replication' }
       its('auth_method.uniq') { should cmp 'md5' }
     end
   end
-  describe postgres_hba_conf(PG_HBA_CONF_FILE).where { type == 'host' } do
+  describe postgres_hba_conf(pg_hba_conf_file).where { type == 'host' } do
     its('auth_method.uniq') { should cmp 'md5'}
   end
 end

--- a/controls/V-72863.rb
+++ b/controls/V-72863.rb
@@ -19,27 +19,27 @@ Source: STIG.DOD.MIL
 uri: http://iase.disa.mil
 -----------------
 =end
-PG_DBA = attribute(
+pg_dba = attribute(
   'pg_dba',
   description: 'The postgres DBA user to access the test database',
 )
 
-PG_DBA_PASSWORD = attribute(
+pg_dba_password = attribute(
   'pg_dba_password',
   description: 'The password for the postgres DBA user',
 )
 
-PG_DB = attribute(
+pg_db = attribute(
   'pg_db',
   description: 'The database used for tests',
 )
 
-PG_HOST = attribute(
+pg_host = attribute(
   'pg_host',
   description: 'The hostname or IP address used to connect to the database',
 )
 
-PG_MAX_CONNECTIONS = attribute(
+pg_max_connections = attribute(
   'pg_max_connections',
   description: 'The maximum number of connections a user can have open at one time',
 )
@@ -120,13 +120,13 @@ control "V-72863" do
 
       $ psql -c \"ALTER ROLE <rolname> CONNECTION LIMIT 1\";"
 
-  sql = postgres_session(PG_DBA, PG_DBA_PASSWORD, PG_HOST)
+  sql = postgres_session(pg_dba, pg_dba_password, pg_host)
 
-  describe sql.query('SHOW max_connections;', [PG_DB]) do
-    its('output') { should be <= PG_MAX_CONNECTIONS }
+  describe sql.query('SHOW max_connections;', [pg_db]) do
+    its('output') { should be <= pg_max_connections }
   end
 
-  describe sql.query('SELECT rolname, rolconnlimit from pg_authid;', [PG_DB]) do
+  describe sql.query('SELECT rolname, rolconnlimit from pg_authid;', [pg_db]) do
     its('output') { should_not include '-1' }
   end
 end

--- a/controls/V-72865.rb
+++ b/controls/V-72865.rb
@@ -19,42 +19,42 @@ Source: STIG.DOD.MIL
 uri: http://iase.disa.mil
 -----------------
 =end
-PG_OWNER = attribute(
+pg_owner = attribute(
   'pg_owner',
   description: "The system user of the postgres process",
 )
 
-PG_GROUP = attribute(
+pg_group = attribute(
   'pg_group',
   description: "The system group of the postgres process",
 )
 
-PG_DBA = attribute(
+pg_dba = attribute(
   'pg_dba',
   description: 'The postgres DBA user to access the test database',
 )
 
-PG_DBA_PASSWORD = attribute(
+pg_dba_password = attribute(
   'pg_dba_password',
   description: 'The password for the postgres DBA user',
 )
 
-PG_DB = attribute(
+pg_db = attribute(
   'pg_db',
   description: 'The database used for tests',
 )
 
-PG_HOST = attribute(
+pg_host = attribute(
   'pg_host',
   description: 'The hostname or IP address used to connect to the database',
 )
 
-PG_DATA_DIR = attribute(
+pg_data_dir = attribute(
   'pg_data_dir',
   description: 'The postgres data directory',
 )
 
-PG_SUPERUSERS = attribute(
+pg_superusers = attribute(
   'pg_superusers',
   description: 'Authorized superuser accounts',
 )
@@ -116,9 +116,9 @@ control "V-72865" do
                 ALTER ROLE bob NOINHERIT;
                 REVOKE SELECT ON some_function FROM bob;"
 
-  sql = postgres_session(PG_DBA, PG_DBA_PASSWORD, PG_HOST)
+  sql = postgres_session(pg_dba, pg_dba_password, pg_host)
 
-  authorized_owners = PG_SUPERUSERS
+  authorized_owners = pg_superusers
   owners = authorized_owners.join('|')
 
   object_granted_privileges = 'arwdDxtU'
@@ -138,7 +138,7 @@ control "V-72865" do
     "WHERE c.relkind IN ('r', 'v', 'm', 'S', 'f');"
 
   databases_sql = 'SELECT datname FROM pg_catalog.pg_database where not datistemplate;'
-  databases_query = sql.query(databases_sql, [PG_DB])
+  databases_query = sql.query(databases_sql, [pg_db])
   databases = databases_query.lines
 
   databases.each do |database|
@@ -173,9 +173,9 @@ control "V-72865" do
     end
   end
 
-  describe directory(PG_DATA_DIR) do
+  describe directory(pg_data_dir) do
     it { should be_directory }
-    it { should be_owned_by PG_OWNER }
+    it { should be_owned_by pg_owner }
     its('mode') { should cmp '0700' }
   end
 end

--- a/controls/V-72867.rb
+++ b/controls/V-72867.rb
@@ -19,27 +19,27 @@ Source: STIG.DOD.MIL
 uri: http://iase.disa.mil
 -----------------
 =end
-PG_DBA = attribute(
+pg_dba = attribute(
   'pg_dba',
   description: 'The postgres DBA user to access the test database',
 )
 
-PG_DBA_PASSWORD = attribute(
+pg_dba_password = attribute(
   'pg_dba_password',
   description: 'The password for the postgres DBA user',
 )
 
-PG_DB = attribute(
+pg_db = attribute(
   'pg_db',
   description: 'The database used for tests',
 )
 
-PG_HOST = attribute(
+pg_host = attribute(
   'pg_host',
   description: 'The hostname or IP address used to connect to the database',
 )
 
-PG_SUPERUSERS = attribute(
+pg_superusers = attribute(
   'pg_superusers',
   description: 'Authorized superuser accounts',
 )
@@ -88,12 +88,12 @@ control "V-72867" do
   For the complete list of permissions allowed by roles, see the official
   documentation: https://www.postgresql.org/docs/current/static/sql-createrole.html"
 
-  sql = postgres_session(PG_DBA, PG_DBA_PASSWORD, PG_HOST)
+  sql = postgres_session(pg_dba, pg_dba_password, pg_host)
 
-  authorized_roles = PG_SUPERUSERS
+  authorized_roles = pg_superusers
 
   roles_sql = 'SELECT r.rolname FROM pg_catalog.pg_roles r where r.rolsuper;'
-  describe sql.query(roles_sql, [PG_DB]) do
+  describe sql.query(roles_sql, [pg_db]) do
     its('lines.sort') { should cmp authorized_roles.sort }
   end
 end

--- a/controls/V-72883.rb
+++ b/controls/V-72883.rb
@@ -19,32 +19,32 @@ Source: STIG.DOD.MIL
 uri: http://iase.disa.mil
 -----------------
 =end
-PG_OWNER = attribute(
+pg_owner = attribute(
   'pg_owner',
   description: "The system user of the postgres process",
 )
 
-PG_DBA = attribute(
+pg_dba = attribute(
   'pg_dba',
   description: 'The postgres DBA user to access the test database',
 )
 
-PG_DBA_PASSWORD = attribute(
+pg_dba_password = attribute(
   'pg_dba_password',
   description: 'The password for the postgres DBA user',
 )
 
-PG_DB = attribute(
+pg_db = attribute(
   'pg_db',
   description: 'The database used for tests',
 )
 
-PG_HOST = attribute(
+pg_host = attribute(
   'pg_host',
   description: 'The hostname or IP address used to connect to the database',
 )
 
-PG_SUPERUSERS = attribute(
+pg_superusers = attribute(
   'pg_superusers',
   description: 'Authorized superuser accounts',
 )
@@ -123,12 +123,12 @@ control "V-72883" do
   $ psql -c \"REVOKE SELECT ON TABLE test.test_table FROM bob\"
   $ psql -c \"REVOKE CREATE ON SCHEMA test FROM bob\""
 
-  sql = postgres_session(PG_DBA, PG_DBA_PASSWORD, PG_HOST)
+  sql = postgres_session(pg_dba, pg_dba_password, pg_host)
 
-  authorized_owners = PG_SUPERUSERS
+  authorized_owners = pg_superusers
 
-  databases_sql = "SELECT datname FROM pg_catalog.pg_database where datname = '#{PG_DB}';"
-  databases_query = sql.query(databases_sql, [PG_DB])
+  databases_sql = "SELECT datname FROM pg_catalog.pg_database where datname = '#{pg_db}';"
+  databases_query = sql.query(databases_sql, [pg_db])
   databases = databases_query.lines
   types = %w(t s v) # tables, sequences views
 
@@ -139,12 +139,12 @@ control "V-72883" do
     if database == 'postgres'
       schemas_sql = "SELECT n.nspname, pg_catalog.pg_get_userbyid(n.nspowner) "\
         "FROM pg_catalog.pg_namespace n "\
-        "WHERE pg_catalog.pg_get_userbyid(n.nspowner) <> '#{PG_OWNER}';"
+        "WHERE pg_catalog.pg_get_userbyid(n.nspowner) <> '#{pg_owner}';"
       functions_sql = "SELECT n.nspname, p.proname, "\
         "pg_catalog.pg_get_userbyid(n.nspowner) "\
         "FROM pg_catalog.pg_proc p "\
         "LEFT JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace "\
-        "WHERE pg_catalog.pg_get_userbyid(n.nspowner) <> '#{PG_OWNER}';"
+        "WHERE pg_catalog.pg_get_userbyid(n.nspowner) <> '#{pg_owner}';"
     else
       schemas_sql = "SELECT n.nspname, pg_catalog.pg_get_userbyid(n.nspowner) "\
         "FROM pg_catalog.pg_namespace n "\
@@ -163,7 +163,7 @@ control "V-72883" do
     connection_error = "FATAL:\\s+database \"#{database}\" is not currently "\
       "accepting connections"
     connection_error_regex = Regexp.new(connection_error)
-    
+
     sql_result=sql.query(schemas_sql, [database])
 
     describe.one do
@@ -196,7 +196,7 @@ control "V-72883" do
           "pg_catalog.pg_get_userbyid(n.nspowner) FROM pg_catalog.pg_class c "\
           "LEFT JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace "\
           "WHERE c.relkind IN ('#{type}','s','') "\
-          "AND pg_catalog.pg_get_userbyid(n.nspowner) <> '#{PG_OWNER}' "
+          "AND pg_catalog.pg_get_userbyid(n.nspowner) <> '#{pg_owner}' "
           "AND n.nspname !~ '^pg_toast';"
       else
         objects_sql = "SELECT n.nspname, c.relname, c.relkind, "\

--- a/controls/V-72887.rb
+++ b/controls/V-72887.rb
@@ -19,27 +19,27 @@ Source: STIG.DOD.MIL
 uri: http://iase.disa.mil
 -----------------
 =end
-PG_DBA = attribute(
+pg_dba = attribute(
   'pg_dba',
   description: 'The postgres DBA user to access the test database',
 )
 
-PG_DBA_PASSWORD = attribute(
+pg_dba_password = attribute(
   'pg_dba_password',
   description: 'The password for the postgres DBA user',
 )
 
-PG_DB = attribute(
+pg_db = attribute(
   'pg_db',
   description: 'The database used for tests',
 )
 
-PG_HOST = attribute(
+pg_host = attribute(
   'pg_host',
   description: 'The hostname or IP address used to connect to the database',
 )
 
-PG_TIMEZONE = attribute(
+pg_timezone = attribute(
   'pg_timezone',
   description: 'PostgreSQL timezone',
 )
@@ -89,9 +89,9 @@ control "V-72887" do
   # INITD SERVER ONLY
   $ sudo service postgresql-9.5 restart"
 
-  sql = postgres_session(PG_DBA, PG_DBA_PASSWORD, PG_HOST)
+  sql = postgres_session(pg_dba, pg_dba_password, pg_host)
 
-  describe sql.query('SHOW log_timezone;', [PG_DB]) do
-    its('output') { should eq PG_TIMEZONE }
+  describe sql.query('SHOW log_timezone;', [pg_db]) do
+    its('output') { should eq pg_timezone }
   end
 end

--- a/controls/V-72891.rb
+++ b/controls/V-72891.rb
@@ -19,37 +19,37 @@ Source: STIG.DOD.MIL
 uri: http://iase.disa.mil
 -----------------
 =end
-PG_OWNER = attribute(
+pg_owner = attribute(
   'pg_owner',
   description: "The system user of the postgres process",
 )
 
-PG_DBA = attribute(
+pg_dba = attribute(
   'pg_dba',
   description: 'The postgres DBA user to access the test database',
 )
 
-PG_DBA_PASSWORD = attribute(
+pg_dba_password = attribute(
   'pg_dba_password',
   description: 'The password for the postgres DBA user',
 )
 
-PG_DB = attribute(
+pg_db = attribute(
   'pg_db',
   description: 'The database used for tests',
 )
 
-PG_HOST = attribute(
+pg_host = attribute(
   'pg_host',
   description: 'The hostname or IP address used to connect to the database',
 )
 
-PG_DATA_DIR = attribute(
+pg_data_dir = attribute(
   'pg_data_dir',
   description: 'The postgres data directory',
 )
 
-PG_SUPERUSERS = attribute(
+pg_superusers = attribute(
   'pg_superusers',
   description: 'Authorized superuser accounts',
 )
@@ -104,24 +104,24 @@ control "V-72891" do
   $ chown postgres:postgres ${PGDATA?}/postgresql.conf
   $ chmod 600 ${PGDATA?}/postgresql.conf"
 
-  describe directory(PG_DATA_DIR) do
+  describe directory(pg_data_dir) do
     it { should be_directory }
-    it { should be_owned_by PG_OWNER }
+    it { should be_owned_by pg_owner }
     its('mode') { should cmp '0700' }
   end
 
-  sql = postgres_session(PG_DBA, PG_DBA_PASSWORD, PG_HOST)
+  sql = postgres_session(pg_dba, pg_dba_password, pg_host)
 
   roles_sql = 'SELECT r.rolname FROM pg_catalog.pg_roles r;'
-  roles_query = sql.query(roles_sql, [PG_DB])
+  roles_query = sql.query(roles_sql, [pg_db])
   roles = roles_query.lines
 
   roles.each do |role|
-    unless PG_SUPERUSERS.include?(role)
+    unless pg_superusers.include?(role)
       superuser_sql = "SELECT r.rolsuper FROM pg_catalog.pg_roles r "\
         "WHERE r.rolname = '#{role}';"
 
-      describe sql.query(superuser_sql, [PG_DB]) do
+      describe sql.query(superuser_sql, [pg_db]) do
         its('output') { should_not eq 't' }
       end
     end

--- a/controls/V-72895.rb
+++ b/controls/V-72895.rb
@@ -19,22 +19,22 @@ Source: STIG.DOD.MIL
 uri: http://iase.disa.mil
 -----------------
 =end
-PG_DBA = attribute(
+pg_dba = attribute(
   'pg_dba',
   description: 'The postgres DBA user to access the test database',
 )
 
-PG_DBA_PASSWORD = attribute(
+pg_dba_password = attribute(
   'pg_dba_password',
   description: 'The password for the postgres DBA user',
 )
 
-PG_DB = attribute(
+pg_db = attribute(
   'pg_db',
   description: 'The database used for tests',
 )
 
-PG_HOST = attribute(
+pg_host = attribute(
   'pg_host',
   description: 'The hostname or IP address used to connect to the database',
 )
@@ -95,9 +95,9 @@ control "V-72895" do
   To configure PostgreSQL to use SSL, see supplementary content APPENDIX-G for
   instructions on enabling SSL."
 
-  sql = postgres_session(PG_DBA, PG_DBA_PASSWORD, PG_HOST)
+  sql = postgres_session(pg_dba, pg_dba_password, pg_host)
 
-  describe sql.query('SHOW ssl;', [PG_DB]) do
+  describe sql.query('SHOW ssl;', [pg_db]) do
     its('output') { should_not match /off|false/i }
   end
 end

--- a/controls/V-72897.rb
+++ b/controls/V-72897.rb
@@ -19,32 +19,32 @@ Source: STIG.DOD.MIL
 uri: http://iase.disa.mil
 -----------------
 =end
-PG_OWNER = attribute(
+pg_owner = attribute(
   'pg_owner',
   description: "The system user of the postgres process",
 )
 
-PG_DBA = attribute(
+pg_dba = attribute(
   'pg_dba',
   description: 'The postgres DBA user to access the test database',
 )
 
-PG_DBA_PASSWORD = attribute(
+pg_dba_password = attribute(
   'pg_dba_password',
   description: 'The password for the postgres DBA user',
 )
 
-PG_DB = attribute(
+pg_db = attribute(
   'pg_db',
   description: 'The database used for tests',
 )
 
-PG_HOST = attribute(
+pg_host = attribute(
   'pg_host',
   description: 'The hostname or IP address used to connect to the database',
 )
 
-PG_SUPERUSERS = attribute(
+pg_superusers = attribute(
   'pg_superusers',
   description: 'Authorized superuser accounts',
 )
@@ -95,13 +95,13 @@ control "V-72897" do
   $ sudo su - postgres
   $ psql -c \"ALTER SCHEMA test OWNER TO bob\""
 
-  sql = postgres_session(PG_DBA, PG_DBA_PASSWORD, PG_HOST)
+  sql = postgres_session(pg_dba, pg_dba_password, pg_host)
 
-  authorized_owners = PG_SUPERUSERS
+  authorized_owners = pg_superusers
 
 
-  databases_sql = "SELECT datname FROM pg_catalog.pg_database where datname = '#{PG_DB}';"
-  databases_query = sql.query(databases_sql, [PG_DB])
+  databases_sql = "SELECT datname FROM pg_catalog.pg_database where datname = '#{pg_db}';"
+  databases_query = sql.query(databases_sql, [pg_db])
   databases = databases_query.lines
   types = %w(t s v) # tables, sequences views
 
@@ -112,12 +112,12 @@ control "V-72897" do
     if database == 'postgres'
       schemas_sql = "SELECT n.nspname, pg_catalog.pg_get_userbyid(n.nspowner) "\
         "FROM pg_catalog.pg_namespace n "\
-        "WHERE pg_catalog.pg_get_userbyid(n.nspowner) <> '#{PG_OWNER}';"
+        "WHERE pg_catalog.pg_get_userbyid(n.nspowner) <> '#{pg_owner}';"
       functions_sql = "SELECT n.nspname, p.proname, "\
         "pg_catalog.pg_get_userbyid(n.nspowner) "\
         "FROM pg_catalog.pg_proc p "\
         "LEFT JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace "\
-        "WHERE pg_catalog.pg_get_userbyid(n.nspowner) <> '#{PG_OWNER}';"
+        "WHERE pg_catalog.pg_get_userbyid(n.nspowner) <> '#{pg_owner}';"
     else
       schemas_sql = "SELECT n.nspname, pg_catalog.pg_get_userbyid(n.nspowner) "\
         "FROM pg_catalog.pg_namespace n "\
@@ -169,7 +169,7 @@ control "V-72897" do
           "pg_catalog.pg_get_userbyid(n.nspowner) FROM pg_catalog.pg_class c "\
           "LEFT JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace "\
           "WHERE c.relkind IN ('#{type}','s','') "\
-          "AND pg_catalog.pg_get_userbyid(n.nspowner) <> '#{PG_OWNER}' "
+          "AND pg_catalog.pg_get_userbyid(n.nspowner) <> '#{pg_owner}' "
           "AND n.nspname !~ '^pg_toast';"
       else
         objects_sql = "SELECT n.nspname, c.relname, c.relkind, "\

--- a/controls/V-72901.rb
+++ b/controls/V-72901.rb
@@ -19,12 +19,12 @@ Source: STIG.DOD.MIL
 uri: http://iase.disa.mil
 -----------------
 =end
-PG_VERSION = attribute(
+pg_version = attribute(
   'pg_version',
   description: "The version of postgres",
 )
 
-PG_SHARED_DIRS = attribute(
+pg_shared_dirs = attribute(
   'pg_shared_dirs',
   description: 'defines the locations of the postgresql shared library directories',
 )
@@ -72,7 +72,7 @@ control "V-72901" do
   other application software that currently shares the PostgreSQL software
   library directory."
 
-  PG_SHARED_DIRS.each do |dir|
+  pg_shared_dirs.each do |dir|
     describe directory(dir) do
       it { should be_directory }
       it { should be_owned_by 'root' }

--- a/controls/V-72905.rb
+++ b/controls/V-72905.rb
@@ -19,22 +19,22 @@ Source: STIG.DOD.MIL
 uri: http://iase.disa.mil
 -----------------
 =end
-PG_DBA = attribute(
+pg_dba = attribute(
   'pg_dba',
   description: 'The postgres DBA user to access the test database',
 )
 
-PG_DBA_PASSWORD = attribute(
+pg_dba_password = attribute(
   'pg_dba_password',
   description: 'The password for the postgres DBA user',
 )
 
-PG_DB = attribute(
+pg_db = attribute(
   'pg_db',
   description: 'The database used for tests',
 )
 
-PG_HOST = attribute(
+pg_host = attribute(
   'pg_host',
   description: 'The hostname or IP address used to connect to the database',
 )
@@ -93,14 +93,14 @@ control "V-72905" do
   $ sudo su - postgres
   $ psql -c \"ALTER FUNCTION <function_name> SECURITY INVOKER;\""
 
-  sql = postgres_session(PG_DBA, PG_DBA_PASSWORD, PG_HOST)
+  sql = postgres_session(pg_dba, pg_dba_password, pg_host)
 
   security_definer_sql = "SELECT nspname, proname, prosecdef "\
     "FROM pg_proc p JOIN pg_namespace n ON p.pronamespace = n.oid "\
     "JOIN pg_authid a ON a.oid = p.proowner WHERE prosecdef = 't';"
 
-  databases_sql = "SELECT datname FROM pg_catalog.pg_database where datname = '#{PG_DB}';"
-  databases_query = sql.query(databases_sql, [PG_DB])
+  databases_sql = "SELECT datname FROM pg_catalog.pg_database where datname = '#{pg_db}';"
+  databases_query = sql.query(databases_sql, [pg_db])
   databases = databases_query.lines
 
   databases.each do |database|

--- a/controls/V-72909.rb
+++ b/controls/V-72909.rb
@@ -19,22 +19,22 @@ Source: STIG.DOD.MIL
 uri: http://iase.disa.mil
 -----------------
 =end
-PG_DBA = attribute(
+pg_dba = attribute(
   'pg_dba',
   description: 'The postgres DBA user to access the test database',
 )
 
-PG_DBA_PASSWORD = attribute(
+pg_dba_password = attribute(
   'pg_dba_password',
   description: 'The password for the postgres DBA user',
 )
 
-PG_DB = attribute(
+pg_db = attribute(
   'pg_db',
   description: 'The database used for tests',
 )
 
-PG_HOST = attribute(
+pg_host = attribute(
   'pg_host',
   description: 'The hostname or IP address used to connect to the database',
 )
@@ -98,13 +98,13 @@ control "V-72909" do
   # INITD SERVER ONLY
   $ sudo service postgresql-9.5 reload"
 
-  sql = postgres_session(PG_DBA, PG_DBA_PASSWORD, PG_HOST)
+  sql = postgres_session(pg_dba, pg_dba_password, pg_host)
 
-  describe sql.query('SHOW log_destination;', [PG_DB]) do
+  describe sql.query('SHOW log_destination;', [pg_db]) do
     its('output') { should match /syslog/i }
   end
 
-  describe sql.query('SHOW syslog_facility;', [PG_DB]) do
+  describe sql.query('SHOW syslog_facility;', [pg_db]) do
     its('output') { should match /local[0-7]/i }
   end
 end

--- a/controls/V-72911.rb
+++ b/controls/V-72911.rb
@@ -19,49 +19,49 @@ Source: STIG.DOD.MIL
 uri: http://iase.disa.mil
 -----------------
 =end
-PG_OWNER = attribute(
+pg_owner = attribute(
   'pg_owner',
   description: "The system user of the postgres process",
 )
 
-PG_DBA = attribute(
+pg_dba = attribute(
   'pg_dba',
   description: 'The postgres DBA user to access the test database',
 )
 
-PG_DBA_PASSWORD = attribute(
+pg_dba_password = attribute(
   'pg_dba_password',
   description: 'The password for the postgres DBA user',
 )
 
-PG_DB = attribute(
+pg_db = attribute(
   'pg_db',
   description: 'The database used for tests',
 )
 
-PG_HOST = attribute(
+pg_host = attribute(
   'pg_host',
   description: 'The hostname or IP address used to connect to the database',
 )
 
-PG_SUPERUSERS = attribute(
+pg_superusers = attribute(
   'pg_superusers',
   description: 'Authorized superuser accounts',
 )
 
-PG_OBJECT_GRANTED_PRIVILEGES = attribute(
+pg_object_granted_privileges = attribute(
   'pg_object_granted_privileges',
   description: 'Privileges that can be granted to a role for a database object',
   default: 'arwdDxt'
 )
 
-PG_OBJECT_PUBLIC_PRIVILEGES = attribute(
+pg_object_public_privileges = attribute(
   'pg_object_public_privileges',
   description: 'Privileges that can be granted to public for a database object',
   default: 'r'
 )
 
-PG_OBJECT_EXCEPTIONS = attribute(
+pg_object_exceptions = attribute(
   'pg_object_exceptions',
   description: 'List of database objects that should be excepted from tests',
   default: ['pg_settings']
@@ -131,11 +131,11 @@ Repeat using \\df+*.* to review ownership of
   database administrator(s). Access to the database administrator account(s)
   must not be granted to anyone without official approval."
 
-  exceptions = "#{PG_OBJECT_EXCEPTIONS.map { |e| "'#{e}'" }.join(',')}"
-  object_acl = "^(((#{PG_OWNER}=[#{PG_OBJECT_GRANTED_PRIVILEGES}]+|"\
-    "=[#{PG_OBJECT_PUBLIC_PRIVILEGES}]+)\\/\\w+,?)+|)$"
+  exceptions = "#{pg_object_exceptions.map { |e| "'#{e}'" }.join(',')}"
+  object_acl = "^(((#{pg_owner}=[#{pg_object_granted_privileges}]+|"\
+    "=[#{pg_object_public_privileges}]+)\\/\\w+,?)+|)$"
   schemas = ['pg_catalog', 'information_schema']
-  sql = postgres_session(PG_DBA, PG_DBA_PASSWORD, PG_HOST)
+  sql = postgres_session(pg_dba, pg_dba_password, pg_host)
 
   schemas.each do |schema|
     objects_sql = "SELECT n.nspname, c.relname, c.relkind, "\
@@ -146,7 +146,7 @@ Repeat using \\df+*.* to review ownership of
       "AND pg_catalog.array_to_string(c.relacl, E',') !~ '#{object_acl}' "\
       "AND c.relname NOT IN (#{exceptions});"
 
-    describe sql.query(objects_sql, [PG_DB]) do
+    describe sql.query(objects_sql, [pg_db]) do
       its('output') { should eq '' }
     end
 
@@ -155,9 +155,9 @@ Repeat using \\df+*.* to review ownership of
       "FROM pg_catalog.pg_proc p "\
       "LEFT JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace "\
       "WHERE n.nspname ~ '^(#{schema})$' "\
-      "AND pg_catalog.pg_get_userbyid(n.nspowner) <> '#{PG_OWNER}';"
+      "AND pg_catalog.pg_get_userbyid(n.nspowner) <> '#{pg_owner}';"
 
-    describe sql.query(functions_sql, [PG_DB]) do
+    describe sql.query(functions_sql, [pg_db]) do
       its('output') { should eq '' }
     end
   end

--- a/controls/V-72919.rb
+++ b/controls/V-72919.rb
@@ -19,22 +19,22 @@ Source: STIG.DOD.MIL
 uri: http://iase.disa.mil
 -----------------
 =end
-PG_DBA = attribute(
+pg_dba = attribute(
   'pg_dba',
   description: 'The postgres DBA user to access the test database',
 )
 
-PG_DBA_PASSWORD = attribute(
+pg_dba_password = attribute(
   'pg_dba_password',
   description: 'The password for the postgres DBA user',
 )
 
-PG_DB = attribute(
+pg_db = attribute(
   'pg_db',
   description: 'The database used for tests',
 )
 
-PG_HOST = attribute(
+pg_host = attribute(
   'pg_host',
   description: 'The hostname or IP address used to connect to the database',
 )
@@ -78,12 +78,12 @@ control "V-72919" do
   # INITD SERVER ONLY
   $ sudo service postgresql-9.5 reload"
 
-  sql = postgres_session(PG_DBA, PG_DBA_PASSWORD, PG_HOST)
+  sql = postgres_session(pg_dba, pg_dba_password, pg_host)
 
   pgaudit_types = %w(ddl role write)
 
   pgaudit_types.each do |type|
-    describe sql.query('SHOW pgaudit.log;', [PG_DB]) do
+    describe sql.query('SHOW pgaudit.log;', [pg_db]) do
       its('output') { should include type }
     end
   end

--- a/controls/V-72931.rb
+++ b/controls/V-72931.rb
@@ -19,22 +19,22 @@ Source: STIG.DOD.MIL
 uri: http://iase.disa.mil
 -----------------
 =end
-PG_DBA = attribute(
+pg_dba = attribute(
   'pg_dba',
   description: 'The postgres DBA user to access the test database',
 )
 
-PG_DBA_PASSWORD = attribute(
+pg_dba_password = attribute(
   'pg_dba_password',
   description: 'The password for the postgres DBA user',
 )
 
-PG_DB = attribute(
+pg_db = attribute(
   'pg_db',
   description: 'The database used for tests',
 )
 
-PG_HOST = attribute(
+pg_host = attribute(
   'pg_host',
   description: 'The hostname or IP address used to connect to the database',
 )
@@ -86,16 +86,16 @@ control "V-72931" do
   # INITD SERVER ONLY
   $ sudo service postgresql-9.5 reload"
 
-  sql = postgres_session(PG_DBA, PG_DBA_PASSWORD, PG_HOST)
+  sql = postgres_session(pg_dba, pg_dba_password, pg_host)
 
-  describe sql.query('SHOW shared_preload_libraries;', [PG_DB]) do
+  describe sql.query('SHOW shared_preload_libraries;', [pg_db]) do
     its('output') { should include 'pgaudit' }
   end
 
   pgaudit_types = %w(ddl read role write)
 
   pgaudit_types.each do |type|
-    describe sql.query('SHOW pgaudit.log;', [PG_DB]) do
+    describe sql.query('SHOW pgaudit.log;', [pg_db]) do
       its('output') { should include type }
     end
   end

--- a/controls/V-72949.rb
+++ b/controls/V-72949.rb
@@ -19,22 +19,22 @@ Source: STIG.DOD.MIL
 uri: http://iase.disa.mil
 -----------------
 =end
-PG_DBA = attribute(
+pg_dba = attribute(
   'pg_dba',
   description: 'The postgres DBA user to access the test database',
 )
 
-PG_DBA_PASSWORD = attribute(
+pg_dba_password = attribute(
   'pg_dba_password',
   description: 'The password for the postgres DBA user',
 )
 
-PG_DB = attribute(
+pg_db = attribute(
   'pg_db',
   description: 'The database used for tests',
 )
 
-PG_HOST = attribute(
+pg_host = attribute(
   'pg_host',
   description: 'The hostname or IP address used to connect to the database',
 )
@@ -82,16 +82,16 @@ control "V-72949" do
   # INITD SERVER ONLY
   $ sudo service postgresql-9.5 reload"
 
-  sql = postgres_session(PG_DBA, PG_DBA_PASSWORD, PG_HOST)
+  sql = postgres_session(pg_dba, pg_dba_password, pg_host)
 
-  describe sql.query('SHOW shared_preload_libraries;', [PG_DB]) do
+  describe sql.query('SHOW shared_preload_libraries;', [pg_db]) do
     its('output') { should include 'pgaudit' }
   end
 
   pgaudit_types = %w(ddl read role write)
 
   pgaudit_types.each do |type|
-    describe sql.query('SHOW pgaudit.log;', [PG_DB]) do
+    describe sql.query('SHOW pgaudit.log;', [pg_db]) do
       its('output') { should include type }
     end
   end

--- a/controls/V-72953.rb
+++ b/controls/V-72953.rb
@@ -19,22 +19,22 @@ Source: STIG.DOD.MIL
 uri: http://iase.disa.mil
 -----------------
 =end
-PG_DBA = attribute(
+pg_dba = attribute(
   'pg_dba',
   description: 'The postgres DBA user to access the test database',
 )
 
-PG_DBA_PASSWORD = attribute(
+pg_dba_password = attribute(
   'pg_dba_password',
   description: 'The password for the postgres DBA user',
 )
 
-PG_DB = attribute(
+pg_db = attribute(
   'pg_db',
   description: 'The database used for tests',
 )
 
-PG_HOST = attribute(
+pg_host = attribute(
   'pg_host',
   description: 'The hostname or IP address used to connect to the database',
 )
@@ -105,16 +105,16 @@ control "V-72953" do
   # INITD SERVER ONLY
   $ sudo service postgresql-9.5 reload"
 
-  sql = postgres_session(PG_DBA, PG_DBA_PASSWORD, PG_HOST)
+  sql = postgres_session(pg_dba, pg_dba_password, pg_host)
 
-  describe sql.query('SHOW shared_preload_libraries;', [PG_DB]) do
+  describe sql.query('SHOW shared_preload_libraries;', [pg_db]) do
     its('output') { should include 'pgaudit' }
   end
 
   pgaudit_types = %w(ddl read role write)
 
   pgaudit_types.each do |type|
-    describe sql.query('SHOW pgaudit.log;', [PG_DB]) do
+    describe sql.query('SHOW pgaudit.log;', [pg_db]) do
       its('output') { should include type }
     end
   end

--- a/controls/V-72955.rb
+++ b/controls/V-72955.rb
@@ -19,22 +19,22 @@ Source: STIG.DOD.MIL
 uri: http://iase.disa.mil
 -----------------
 =end
-PG_DBA = attribute(
+pg_dba = attribute(
   'pg_dba',
   description: 'The postgres DBA user to access the test database',
 )
 
-PG_DBA_PASSWORD = attribute(
+pg_dba_password = attribute(
   'pg_dba_password',
   description: 'The password for the postgres DBA user',
 )
 
-PG_DB = attribute(
+pg_db = attribute(
   'pg_db',
   description: 'The database used for tests',
 )
 
-PG_HOST = attribute(
+pg_host = attribute(
   'pg_host',
   description: 'The hostname or IP address used to connect to the database',
 )
@@ -80,12 +80,12 @@ control "V-72955" do
   # INITD SERVER ONLY
   $ sudo service postgresql-9.5 reload"
 
-  sql = postgres_session(PG_DBA, PG_DBA_PASSWORD, PG_HOST)
+  sql = postgres_session(pg_dba, pg_dba_password, pg_host)
 
   pgaudit_types = %w(ddl role write)
 
   pgaudit_types.each do |type|
-    describe sql.query('SHOW pgaudit.log;', [PG_DB]) do
+    describe sql.query('SHOW pgaudit.log;', [pg_db]) do
       its('output') { should include type }
     end
   end

--- a/controls/V-72957.rb
+++ b/controls/V-72957.rb
@@ -19,22 +19,22 @@ Source: STIG.DOD.MIL
 uri: http://iase.disa.mil
 -----------------
 =end
-PG_DBA = attribute(
+pg_dba = attribute(
   'pg_dba',
   description: 'The postgres DBA user to access the test database',
 )
 
-PG_DBA_PASSWORD = attribute(
+pg_dba_password = attribute(
   'pg_dba_password',
   description: 'The password for the postgres DBA user',
 )
 
-PG_DB = attribute(
+pg_db = attribute(
   'pg_db',
   description: 'The database used for tests',
 )
 
-PG_HOST = attribute(
+pg_host = attribute(
   'pg_host',
   description: 'The hostname or IP address used to connect to the database',
 )
@@ -89,16 +89,16 @@ control "V-72957" do
   # INITD SERVER ONLY
   $ sudo service postgresql-9.5 reload"
 
-  sql = postgres_session(PG_DBA, PG_DBA_PASSWORD, PG_HOST)
+  sql = postgres_session(pg_dba, pg_dba_password, pg_host)
 
-  describe sql.query('SHOW shared_preload_libraries;', [PG_DB]) do
+  describe sql.query('SHOW shared_preload_libraries;', [pg_db]) do
     its('output') { should include 'pgaudit' }
   end
 
   pgaudit_types = %w(ddl read role write)
 
   pgaudit_types.each do |type|
-    describe sql.query('SHOW pgaudit.log;', [PG_DB]) do
+    describe sql.query('SHOW pgaudit.log;', [pg_db]) do
       its('output') { should include type }
     end
   end

--- a/controls/V-72959.rb
+++ b/controls/V-72959.rb
@@ -19,22 +19,22 @@ Source: STIG.DOD.MIL
 uri: http://iase.disa.mil
 -----------------
 =end
-PG_DBA = attribute(
+pg_dba = attribute(
   'pg_dba',
   description: 'The postgres DBA user to access the test database',
 )
 
-PG_DBA_PASSWORD = attribute(
+pg_dba_password = attribute(
   'pg_dba_password',
   description: 'The password for the postgres DBA user',
 )
 
-PG_DB = attribute(
+pg_db = attribute(
   'pg_db',
   description: 'The database used for tests',
 )
 
-PG_HOST = attribute(
+pg_host = attribute(
   'pg_host',
   description: 'The hostname or IP address used to connect to the database',
 )
@@ -82,16 +82,16 @@ control "V-72959" do
   # INITD SERVER ONLY
   $ sudo service postgresql-9.5 reload"
 
-  sql = postgres_session(PG_DBA, PG_DBA_PASSWORD, PG_HOST)
+  sql = postgres_session(pg_dba, pg_dba_password, pg_host)
 
-  describe sql.query('SHOW shared_preload_libraries;', [PG_DB]) do
+  describe sql.query('SHOW shared_preload_libraries;', [pg_db]) do
     its('output') { should include 'pgaudit' }
   end
 
   pgaudit_types = %w(ddl read role write)
 
   pgaudit_types.each do |type|
-    describe sql.query('SHOW pgaudit.log;', [PG_DB]) do
+    describe sql.query('SHOW pgaudit.log;', [pg_db]) do
       its('output') { should include type }
     end
   end

--- a/controls/V-72961.rb
+++ b/controls/V-72961.rb
@@ -19,22 +19,22 @@ Source: STIG.DOD.MIL
 uri: http://iase.disa.mil
 -----------------
 =end
-PG_DBA = attribute(
+pg_dba = attribute(
   'pg_dba',
   description: 'The postgres DBA user to access the test database',
 )
 
-PG_DBA_PASSWORD = attribute(
+pg_dba_password = attribute(
   'pg_dba_password',
   description: 'The password for the postgres DBA user',
 )
 
-PG_DB = attribute(
+pg_db = attribute(
   'pg_db',
   description: 'The database used for tests',
 )
 
-PG_HOST = attribute(
+pg_host = attribute(
   'pg_host',
   description: 'The hostname or IP address used to connect to the database',
 )
@@ -97,20 +97,20 @@ control "V-72961" do
   # INITD SERVER ONLY
   $ sudo service postgresql-9.5 reload"
 
-  sql = postgres_session(PG_DBA, PG_DBA_PASSWORD, PG_HOST)
+  sql = postgres_session(pg_dba, pg_dba_password, pg_host)
 
-  describe sql.query('SHOW log_connections;', [PG_DB]) do
+  describe sql.query('SHOW log_connections;', [pg_db]) do
     its('output') { should_not match /off|false/i }
   end
 
-  describe sql.query('SHOW log_disconnections;', [PG_DB]) do
+  describe sql.query('SHOW log_disconnections;', [pg_db]) do
     its('output') { should_not match /off|false/i }
   end
 
   log_line_prefix_escapes = %w(%m %u %d %c)
 
   log_line_prefix_escapes.each do |escape|
-    describe sql.query('SHOW log_line_prefix;', [PG_DB]) do
+    describe sql.query('SHOW log_line_prefix;', [pg_db]) do
       its('output') { should include escape }
     end
   end

--- a/controls/V-72963.rb
+++ b/controls/V-72963.rb
@@ -19,22 +19,22 @@ Source: STIG.DOD.MIL
 uri: http://iase.disa.mil
 -----------------
 =end
-PG_DBA = attribute(
+pg_dba = attribute(
   'pg_dba',
   description: 'The postgres DBA user to access the test database',
 )
 
-PG_DBA_PASSWORD = attribute(
+pg_dba_password = attribute(
   'pg_dba_password',
   description: 'The password for the postgres DBA user',
 )
 
-PG_DB = attribute(
+pg_db = attribute(
   'pg_db',
   description: 'The database used for tests',
 )
 
-PG_HOST = attribute(
+pg_host = attribute(
   'pg_host',
   description: 'The hostname or IP address used to connect to the database',
 )
@@ -85,16 +85,16 @@ control "V-72963" do
   # INITD SERVER ONLY
   $ sudo service postgresql-9.5 reload"
 
-  sql = postgres_session(PG_DBA, PG_DBA_PASSWORD, PG_HOST)
+  sql = postgres_session(pg_dba, pg_dba_password, pg_host)
 
-  describe sql.query('SHOW shared_preload_libraries;', [PG_DB]) do
+  describe sql.query('SHOW shared_preload_libraries;', [pg_db]) do
     its('output') { should include 'pgaudit' }
   end
 
   pgaudit_types = %w(ddl read role write)
 
   pgaudit_types.each do |type|
-    describe sql.query('SHOW pgaudit.log;', [PG_DB]) do
+    describe sql.query('SHOW pgaudit.log;', [pg_db]) do
       its('output') { should include type }
     end
   end

--- a/controls/V-72965.rb
+++ b/controls/V-72965.rb
@@ -19,22 +19,22 @@ Source: STIG.DOD.MIL
 uri: http://iase.disa.mil
 -----------------
 =end
-PG_DBA = attribute(
+pg_dba = attribute(
   'pg_dba',
   description: 'The postgres DBA user to access the test database',
 )
 
-PG_DBA_PASSWORD = attribute(
+pg_dba_password = attribute(
   'pg_dba_password',
   description: 'The password for the postgres DBA user',
 )
 
-PG_DB = attribute(
+pg_db = attribute(
   'pg_db',
   description: 'The database used for tests',
 )
 
-PG_HOST = attribute(
+pg_host = attribute(
   'pg_host',
   description: 'The hostname or IP address used to connect to the database',
 )
@@ -82,16 +82,16 @@ control "V-72965" do
   # INITD SERVER ONLY
   $ sudo service postgresql-9.5 reload"
 
-  sql = postgres_session(PG_DBA, PG_DBA_PASSWORD, PG_HOST)
+  sql = postgres_session(pg_dba, pg_dba_password, pg_host)
 
-  describe sql.query('SHOW shared_preload_libraries;', [PG_DB]) do
+  describe sql.query('SHOW shared_preload_libraries;', [pg_db]) do
     its('output') { should include 'pgaudit' }
   end
 
   pgaudit_types = ['role']
 
   pgaudit_types.each do |type|
-    describe sql.query('SHOW pgaudit.log;', [PG_DB]) do
+    describe sql.query('SHOW pgaudit.log;', [pg_db]) do
       its('output') { should include type }
     end
   end

--- a/controls/V-72971.rb
+++ b/controls/V-72971.rb
@@ -19,22 +19,22 @@ Source: STIG.DOD.MIL
 uri: http://iase.disa.mil
 -----------------
 =end
-PG_DBA = attribute(
+pg_dba = attribute(
   'pg_dba',
   description: 'The postgres DBA user to access the test database',
 )
 
-PG_DBA_PASSWORD = attribute(
+pg_dba_password = attribute(
   'pg_dba_password',
   description: 'The password for the postgres DBA user',
 )
 
-PG_DB = attribute(
+pg_db = attribute(
   'pg_db',
   description: 'The database used for tests',
 )
 
-PG_HOST = attribute(
+pg_host = attribute(
   'pg_host',
   description: 'The hostname or IP address used to connect to the database',
 )
@@ -89,21 +89,21 @@ control "V-72971" do
   # INITD SERVER ONLY
   $ sudo service postgresql-9.5 reload"
 
-  sql = postgres_session(PG_DBA, PG_DBA_PASSWORD, PG_HOST)
+  sql = postgres_session(pg_dba, pg_dba_password, pg_host)
 
-  describe sql.query('SHOW shared_preload_libraries;', [PG_DB]) do
+  describe sql.query('SHOW shared_preload_libraries;', [pg_db]) do
     its('output') { should include 'pgaudit' }
   end
 
   pgaudit_types = %w(ddl read role write)
 
   pgaudit_types.each do |type|
-    describe sql.query('SHOW pgaudit.log;', [PG_DB]) do
+    describe sql.query('SHOW pgaudit.log;', [pg_db]) do
       its('output') { should include type }
     end
   end
 
-  describe sql.query('SHOW pgaudit.log_catalog;', [PG_DB]) do
+  describe sql.query('SHOW pgaudit.log_catalog;', [pg_db]) do
     its('output') { should match /on|true/i }
   end
 end

--- a/controls/V-72973.rb
+++ b/controls/V-72973.rb
@@ -19,22 +19,22 @@ Source: STIG.DOD.MIL
 uri: http://iase.disa.mil
 -----------------
 =end
-PG_DBA = attribute(
+pg_dba = attribute(
   'pg_dba',
   description: 'The postgres DBA user to access the test database',
 )
 
-PG_DBA_PASSWORD = attribute(
+pg_dba_password = attribute(
   'pg_dba_password',
   description: 'The password for the postgres DBA user',
 )
 
-PG_DB = attribute(
+pg_db = attribute(
   'pg_db',
   description: 'The database used for tests',
 )
 
-PG_HOST = attribute(
+pg_host = attribute(
   'pg_host',
   description: 'The hostname or IP address used to connect to the database',
 )
@@ -84,16 +84,16 @@ PG_HOST = attribute(
   # INITD SERVER ONLY
   $ sudo service postgresql-9.5 reload"
 
-  sql = postgres_session(PG_DBA, PG_DBA_PASSWORD, PG_HOST)
+  sql = postgres_session(pg_dba, pg_dba_password, pg_host)
 
-  describe sql.query('SHOW shared_preload_libraries;', [PG_DB]) do
+  describe sql.query('SHOW shared_preload_libraries;', [pg_db]) do
     its('output') { should include 'pgaudit' }
   end
 
   pgaudit_types = %w(ddl read role write)
 
   pgaudit_types.each do |type|
-    describe sql.query('SHOW pgaudit.log;', [PG_DB]) do
+    describe sql.query('SHOW pgaudit.log;', [pg_db]) do
       its('output') { should include type }
     end
   end

--- a/controls/V-72979.rb
+++ b/controls/V-72979.rb
@@ -19,32 +19,32 @@ Source: STIG.DOD.MIL
 uri: http://iase.disa.mil
 -----------------
 =end
-PG_DBA = attribute(
+pg_dba = attribute(
   'pg_dba',
   description: 'The postgres DBA user to access the test database',
 )
 
-PG_DBA_PASSWORD = attribute(
+pg_dba_password = attribute(
   'pg_dba_password',
   description: 'The password for the postgres DBA user',
 )
 
-PG_DB = attribute(
+pg_db = attribute(
   'pg_db',
   description: 'The database used for tests',
 )
 
-PG_HOST = attribute(
+pg_host = attribute(
   'pg_host',
   description: 'The hostname or IP address used to connect to the database',
 )
 
-PG_DATA_DIR = attribute(
+pg_data_dir = attribute(
   'pg_data_dir',
   description: 'The postgres data directory',
 )
 
-PG_HBA_CONF_FILE = attribute(
+pg_hba_conf_file = attribute(
   'pg_hba_conf_file',
   description: 'The postgres hba configuration file',
 )
@@ -122,9 +122,9 @@ control "V-72979" do
   # INITD SERVER ONLY
   $ sudo service postgresql-9.5 reload"
 
-  sql = postgres_session(PG_DBA, PG_DBA_PASSWORD, PG_HOST)
+  sql = postgres_session(pg_dba, pg_dba_password, pg_host)
 
-  ssl_crl_file_query = sql.query('SHOW ssl_crl_file;', [PG_DB])
+  ssl_crl_file_query = sql.query('SHOW ssl_crl_file;', [pg_db])
 
   describe ssl_crl_file_query do
     its('output') { should match /^\w+\.crl$/ }
@@ -133,9 +133,9 @@ control "V-72979" do
   ssl_crl_file = ssl_crl_file_query.output
 
   if ssl_crl_file.empty?
-    ssl_crl_file = "#{PG_DATA_DIR}/root.crl"
+    ssl_crl_file = "#{pg_data_dir}/root.crl"
   elsif File.dirname(ssl_crl_file) == '.'
-    ssl_crl_file = "#{PG_DATA_DIR}/#{ssl_crl_file}"
+    ssl_crl_file = "#{pg_data_dir}/#{ssl_crl_file}"
   end
 
   describe file(ssl_crl_file) do
@@ -143,10 +143,10 @@ control "V-72979" do
   end
 
   describe.one do
-    describe postgres_hba_conf(PG_HBA_CONF_FILE).where { type == 'hostssl' } do
+    describe postgres_hba_conf(pg_hba_conf_file).where { type == 'hostssl' } do
       its('auth_method') { should include 'cert' }
     end
-    describe postgres_hba_conf(PG_HBA_CONF_FILE).where { type == 'hostssl' } do
+    describe postgres_hba_conf(pg_hba_conf_file).where { type == 'hostssl' } do
       its('auth_params') { should match [/clientcert=1.*/] }
     end
   end

--- a/controls/V-72981.rb
+++ b/controls/V-72981.rb
@@ -19,22 +19,22 @@ Source: STIG.DOD.MIL
 uri: http://iase.disa.mil
 -----------------
 =end
-PG_DBA = attribute(
+pg_dba = attribute(
   'pg_dba',
   description: 'The postgres DBA user to access the test database',
 )
 
-PG_DBA_PASSWORD = attribute(
+pg_dba_password = attribute(
   'pg_dba_password',
   description: 'The password for the postgres DBA user',
 )
 
-PG_DB = attribute(
+pg_db = attribute(
   'pg_db',
   description: 'The database used for tests',
 )
 
-PG_HOST = attribute(
+pg_host = attribute(
   'pg_host',
   description: 'The hostname or IP address used to connect to the database',
 )
@@ -93,9 +93,9 @@ control "V-72981" do
   For more information on configuring PostgreSQL to use SSL, see supplementary
   content APPENDIX-G."
 
-  sql = postgres_session(PG_DBA, PG_DBA_PASSWORD, PG_HOST)
+  sql = postgres_session(pg_dba, pg_dba_password, pg_host)
 
-  describe sql.query('SHOW ssl;', [PG_DB]) do
+  describe sql.query('SHOW ssl;', [pg_db]) do
     its('output') { should match /on|true/i }
   end
 end

--- a/controls/V-72987.rb
+++ b/controls/V-72987.rb
@@ -19,22 +19,22 @@ Source: STIG.DOD.MIL
 uri: http://iase.disa.mil
 -----------------
 =end
-PG_DBA = attribute(
+pg_dba = attribute(
   'pg_dba',
   description: 'The postgres DBA user to access the test database',
 )
 
-PG_DBA_PASSWORD = attribute(
+pg_dba_password = attribute(
   'pg_dba_password',
   description: 'The password for the postgres DBA user',
 )
 
-PG_DB = attribute(
+pg_db = attribute(
   'pg_db',
   description: 'The database used for tests',
 )
 
-PG_HOST = attribute(
+pg_host = attribute(
   'pg_host',
   description: 'The hostname or IP address used to connect to the database',
 )
@@ -86,12 +86,12 @@ control "V-72987" do
   # INITD SERVER ONLY
   $ sudo service postgresql-9.5 reload"
 
-  sql = postgres_session(PG_DBA, PG_DBA_PASSWORD, PG_HOST)
+  sql = postgres_session(pg_dba, pg_dba_password, pg_host)
 
   log_line_prefix_escapes = %w(%m %u %d %p %r %a)
 
   log_line_prefix_escapes.each do |escape|
-    describe sql.query('SHOW log_line_prefix;', [PG_DB]) do
+    describe sql.query('SHOW log_line_prefix;', [pg_db]) do
       its('output') { should include escape }
     end
   end

--- a/controls/V-72991.rb
+++ b/controls/V-72991.rb
@@ -19,22 +19,22 @@ Source: STIG.DOD.MIL
 uri: http://iase.disa.mil
 -----------------
 =end
-PG_DBA = attribute(
+pg_dba = attribute(
   'pg_dba',
   description: 'The postgres DBA user to access the test database',
 )
 
-PG_DBA_PASSWORD = attribute(
+pg_dba_password = attribute(
   'pg_dba_password',
   description: 'The password for the postgres DBA user',
 )
 
-PG_DB = attribute(
+pg_db = attribute(
   'pg_db',
   description: 'The database used for tests',
 )
 
-PG_HOST = attribute(
+pg_host = attribute(
   'pg_host',
   description: 'The hostname or IP address used to connect to the database',
 )
@@ -106,9 +106,9 @@ APPENDIX-G.
 
 Deploy NSA-approved encrypting devices to protect the server on the network."
 
-  sql = postgres_session(PG_DBA, PG_DBA_PASSWORD, PG_HOST)
+  sql = postgres_session(pg_dba, pg_dba_password, pg_host)
 
-  describe sql.query('SHOW ssl;', [PG_DB]) do
+  describe sql.query('SHOW ssl;', [pg_db]) do
     its('output') { should match /on|true/i }
   end
 end

--- a/controls/V-72995.rb
+++ b/controls/V-72995.rb
@@ -19,22 +19,22 @@ Source: STIG.DOD.MIL
 uri: http://iase.disa.mil
 -----------------
 =end
-PG_DBA = attribute(
+pg_dba = attribute(
   'pg_dba',
   description: 'The postgres DBA user to access the database',
 )
 
-PG_DBA_PASSWORD = attribute(
+pg_dba_password = attribute(
   'pg_dba_password',
   description: "password for the postgres dba password",
 )
 
-PG_DB = attribute(
+pg_db = attribute(
   'pg_db',
   description: 'the default postgres database',
 )
 
-PG_HOST = attribute(
+pg_host = attribute(
   'pg_host',
   description: "Hostname or ip allow to connect to the database",
 )
@@ -94,11 +94,11 @@ With pgcrypto installed, it is possible to insert encrypted data into the databa
 INSERT INTO accounts(username, password) VALUES ('bob', crypt('a_secure_password',
 gen_salt('xdes')));"
 
-  sql = postgres_session(PG_DBA, PG_DBA_PASSWORD, PG_HOST)
+  sql = postgres_session(pg_dba, pg_dba_password, pg_host)
 
   pgcrypto_sql = "SELECT * FROM pg_available_extensions where name='pgcrypto'"
 
-  describe sql.query(pgcrypto_sql, [PG_DB]) do
+  describe sql.query(pgcrypto_sql, [pg_db]) do
     its('output') { should_not eq '' }
   end
 end

--- a/controls/V-72999.rb
+++ b/controls/V-72999.rb
@@ -19,32 +19,32 @@ Source: STIG.DOD.MIL
 uri: http://iase.disa.mil
 -----------------
 =end
-PG_OWNER = attribute(
+pg_owner = attribute(
   'pg_owner',
   description: "The system user of the postgres process",
 )
 
-PG_DBA = attribute(
+pg_dba = attribute(
   'pg_dba',
   description: 'The postgres DBA user to access the test database',
 )
 
-PG_DBA_PASSWORD = attribute(
+pg_dba_password = attribute(
   'pg_dba_password',
   description: 'The password for the postgres DBA user',
 )
 
-PG_DB = attribute(
+pg_db = attribute(
   'pg_db',
   description: 'The database used for tests',
 )
 
-PG_HOST = attribute(
+pg_host = attribute(
   'pg_host',
   description: 'The hostname or IP address used to connect to the database',
 )
 
-PG_SUPERUSERS = attribute(
+pg_superusers = attribute(
   'pg_superusers',
   description: 'Authorized superuser accounts',
 )
@@ -108,19 +108,19 @@ To remove privileges, see the following example:
 ALTER ROLE <username> NOSUPERUSER NOCREATEDB NOCREATEROLE NOBYPASSRLS;"
 
   privileges = %w(rolcreatedb rolcreaterole rolsuper)
-  sql = postgres_session(PG_DBA, PG_DBA_PASSWORD, PG_HOST)
+  sql = postgres_session(pg_dba, pg_dba_password, pg_host)
 
   roles_sql = 'SELECT r.rolname FROM pg_catalog.pg_roles r;'
-  roles_query = sql.query(roles_sql, [PG_DB])
+  roles_query = sql.query(roles_sql, [pg_db])
   roles = roles_query.lines
 
   roles.each do |role|
-    unless PG_SUPERUSERS.include?(role)
+    unless pg_superusers.include?(role)
       privileges.each do |privilege|
         privilege_sql = "SELECT r.#{privilege} FROM pg_catalog.pg_roles r "\
           "WHERE r.rolname = '#{role}';"
 
-        describe sql.query(privilege_sql, [PG_DB]) do
+        describe sql.query(privilege_sql, [pg_db]) do
           its('output') { should_not eq 't' }
         end
       end

--- a/controls/V-73001.rb
+++ b/controls/V-73001.rb
@@ -19,22 +19,22 @@ Source: STIG.DOD.MIL
 uri: http://iase.disa.mil
 -----------------
 =end
-PG_DBA = attribute(
+pg_dba = attribute(
   'pg_dba',
   description: 'The postgres DBA user to access the test database',
 )
 
-PG_DBA_PASSWORD = attribute(
+pg_dba_password = attribute(
   'pg_dba_password',
   description: 'The password for the postgres DBA user',
 )
 
-PG_DB = attribute(
+pg_db = attribute(
   'pg_db',
   description: 'The database used for tests',
 )
 
-PG_HOST = attribute(
+pg_host = attribute(
   'pg_host',
   description: 'The hostname or IP address used to connect to the database',
 )
@@ -76,13 +76,13 @@ instructions on enabling logging.
 For session logging we suggest using pgaudit. For instructions on how to setup
 pgaudit, see supplementary content APPENDIX-B."
 
-  sql = postgres_session(PG_DBA, PG_DBA_PASSWORD, PG_HOST)
+  sql = postgres_session(pg_dba, pg_dba_password, pg_host)
 
-  describe sql.query('SHOW shared_preload_libraries;', [PG_DB]) do
+  describe sql.query('SHOW shared_preload_libraries;', [pg_db]) do
     its('output') { should include 'pgaudit' }
   end
 
-  describe sql.query('SHOW log_destination;', [PG_DB]) do
+  describe sql.query('SHOW log_destination;', [pg_db]) do
     its('output') { should match /stderr|syslog/i }
   end
 end

--- a/controls/V-73003.rb
+++ b/controls/V-73003.rb
@@ -19,22 +19,22 @@ Source: STIG.DOD.MIL
 uri: http://iase.disa.mil
 -----------------
 =end
-PG_DBA = attribute(
+pg_dba = attribute(
   'pg_dba',
   description: 'The postgres DBA user to access the test database',
 )
 
-PG_DBA_PASSWORD = attribute(
+pg_dba_password = attribute(
   'pg_dba_password',
   description: 'The password for the postgres DBA user',
 )
 
-PG_DB = attribute(
+pg_db = attribute(
   'pg_db',
   description: 'The database used for tests',
 )
 
-PG_HOST = attribute(
+pg_host = attribute(
   'pg_host',
   description: 'The hostname or IP address used to connect to the database',
 )
@@ -108,11 +108,11 @@ With pgcrypto installed, it's possible to insert encrypted data into the databas
 INSERT INTO accounts(username, password) VALUES ('bob', crypt('a_secure_password',
 gen_salt('md5')));"
 
-  sql = postgres_session(PG_DBA, PG_DBA_PASSWORD, PG_HOST)
+  sql = postgres_session(pg_dba, pg_dba_password, pg_host)
 
   pgcrypto_sql = "SELECT * FROM pg_available_extensions where name='pgcrypto'"
 
-  describe sql.query(pgcrypto_sql, [PG_DB]) do
+  describe sql.query(pgcrypto_sql, [pg_db]) do
     its('output') { should_not eq '' }
   end
 

--- a/controls/V-73005.rb
+++ b/controls/V-73005.rb
@@ -19,22 +19,22 @@ Source: STIG.DOD.MIL
 uri: http://iase.disa.mil
 -----------------
 =end
-PG_DBA = attribute(
+pg_dba = attribute(
   'pg_dba',
   description: 'The postgres DBA user to access the test database',
 )
 
-PG_DBA_PASSWORD = attribute(
+pg_dba_password = attribute(
   'pg_dba_password',
   description: 'The password for the postgres DBA user',
 )
 
-PG_DB = attribute(
+pg_db = attribute(
   'pg_db',
   description: 'The database used for tests',
 )
 
-PG_HOST = attribute(
+pg_host = attribute(
   'pg_host',
   description: 'The hostname or IP address used to connect to the database',
 )
@@ -129,16 +129,16 @@ $ sudo systemctl reload postgresql-9.5
 # INITD SERVER ONLY
 $ sudo service postgresql-9.5 reload"
 
-  sql = postgres_session(PG_DBA, PG_DBA_PASSWORD, PG_HOST)
+  sql = postgres_session(pg_dba, pg_dba_password, pg_host)
 
   log_line_prefix_escapes = %w(%m %u %d %s)
   log_line_prefix_escapes.each do |escape|
-    describe sql.query('SHOW log_line_prefix;', [PG_DB]) do
+    describe sql.query('SHOW log_line_prefix;', [pg_db]) do
       its('output') { should include escape }
     end
   end
 
-  describe sql.query('SHOW log_hostname;', [PG_DB]) do
+  describe sql.query('SHOW log_hostname;', [pg_db]) do
     its('output') { should match /(on|true)/i }
   end
 end

--- a/controls/V-73015.rb
+++ b/controls/V-73015.rb
@@ -19,22 +19,22 @@ Source: STIG.DOD.MIL
 uri: http://iase.disa.mil
 -----------------
 =end
-PG_DBA = attribute(
+pg_dba = attribute(
   'pg_dba',
   description: 'The postgres DBA user to access the test database',
 )
 
-PG_DBA_PASSWORD = attribute(
+pg_dba_password = attribute(
   'pg_dba_password',
   description: 'The password for the postgres DBA user',
 )
 
-PG_DB = attribute(
+pg_db = attribute(
   'pg_db',
   description: 'The database used for tests',
 )
 
-PG_HOST = attribute(
+pg_host = attribute(
   'pg_host',
   description: 'The hostname or IP address used to connect to the database',
 )
@@ -95,17 +95,17 @@ $ sudo systemctl restart postgresql-9.5
 # INITD SERVER ONLY
 $ sudo service postgresql-9.5 restart"
 
-  sql = postgres_session(PG_DBA, PG_DBA_PASSWORD, PG_HOST)
+  sql = postgres_session(pg_dba, pg_dba_password, pg_host)
 
-  describe sql.query('SHOW password_encryption;', [PG_DB]) do
+  describe sql.query('SHOW password_encryption;', [pg_db]) do
     its('output') { should match /on|true/i }
   end
 
   passwords_sql = "SELECT usename FROM pg_shadow "\
     "WHERE passwd !~ '^md5[0-9a-f]+$';"
 
-  describe sql.query(passwords_sql, [PG_DB]) do
+  describe sql.query(passwords_sql, [pg_db]) do
     its('output') { should eq '' }
   end
-  
+
 end

--- a/controls/V-73017.rb
+++ b/controls/V-73017.rb
@@ -19,32 +19,32 @@ Source: STIG.DOD.MIL
 uri: http://iase.disa.mil
 -----------------
 =end
-PG_OWNER = attribute(
+pg_owner = attribute(
   'pg_owner',
   description: "The system user of the postgres process",
 )
 
-PG_DBA = attribute(
+pg_dba = attribute(
   'pg_dba',
   description: 'The postgres DBA user to access the test database',
 )
 
-PG_DBA_PASSWORD = attribute(
+pg_dba_password = attribute(
   'pg_dba_password',
   description: 'The password for the postgres DBA user',
 )
 
-PG_DB = attribute(
+pg_db = attribute(
   'pg_db',
   description: 'The database used for tests',
 )
 
-PG_HOST = attribute(
+pg_host = attribute(
   'pg_host',
   description: 'The hostname or IP address used to connect to the database',
 )
 
-PG_SUPERUSERS = attribute(
+pg_superusers = attribute(
   'pg_superusers',
   description: 'Authorized superuser accounts',
 )
@@ -98,24 +98,24 @@ Use REVOKE to remove privileges from databases and schemas:
 
 $ psql -c \"REVOKE ALL PRIVILEGES ON <table> FROM <role_name>;"
 
-  sql = postgres_session(PG_DBA, PG_DBA_PASSWORD, PG_HOST)
+  sql = postgres_session(pg_dba, pg_dba_password, pg_host)
 
   roles_sql = 'SELECT r.rolname FROM pg_catalog.pg_roles r;'
-  roles_query = sql.query(roles_sql, [PG_DB])
+  roles_query = sql.query(roles_sql, [pg_db])
   roles = roles_query.lines
 
   roles.each do |role|
-    unless PG_SUPERUSERS.include?(role)
+    unless pg_superusers.include?(role)
       superuser_sql = "SELECT r.rolsuper FROM pg_catalog.pg_roles r "\
         "WHERE r.rolname = '#{role}';"
 
-      describe sql.query(superuser_sql, [PG_DB]) do
+      describe sql.query(superuser_sql, [pg_db]) do
         its('output') { should_not eq 't' }
       end
     end
   end
 
-  authorized_owners = PG_SUPERUSERS
+  authorized_owners = pg_superusers
   owners = authorized_owners.join('|')
 
   database_granted_privileges = 'CTc'
@@ -131,14 +131,14 @@ $ psql -c \"REVOKE ALL PRIVILEGES ON <table> FROM <role_name>;"
   schema_acl_regex = Regexp.new(schema_acl)
 
   databases_sql = 'SELECT datname FROM pg_catalog.pg_database where not datistemplate;'
-  databases_query = sql.query(databases_sql, [PG_DB])
+  databases_query = sql.query(databases_sql, [pg_db])
   databases = databases_query.lines
 
   databases.each do |database|
     datacl_sql = "SELECT pg_catalog.array_to_string(datacl, E','), datname "\
       "FROM pg_catalog.pg_database WHERE datname = '#{database}';"
 
-    describe sql.query(datacl_sql, [PG_DB]) do
+    describe sql.query(datacl_sql, [pg_db]) do
       its('output') { should match database_acl_regex }
     end
 

--- a/controls/V-73019.rb
+++ b/controls/V-73019.rb
@@ -19,22 +19,22 @@ Source: STIG.DOD.MIL
 uri: http://iase.disa.mil
 -----------------
 =end
-PG_DBA = attribute(
+pg_dba = attribute(
   'pg_dba',
   description: 'The postgres DBA user to access the test database',
 )
 
-PG_DBA_PASSWORD = attribute(
+pg_dba_password = attribute(
   'pg_dba_password',
   description: 'The password for the postgres DBA user',
 )
 
-PG_DB = attribute(
+pg_db = attribute(
   'pg_db',
   description: 'The database used for tests',
 )
 
-PG_HOST = attribute(
+pg_host = attribute(
   'pg_host',
   description: 'The hostname or IP address used to connect to the database',
 )
@@ -117,17 +117,17 @@ Use accounts assigned to individual users. Where the application connects to
 PostgreSQL using a standard, shared account, ensure that it also captures the
 individual user identification and passes it to PostgreSQL."
 
-  sql = postgres_session(PG_DBA, PG_DBA_PASSWORD, PG_HOST)
+  sql = postgres_session(pg_dba, pg_dba_password, pg_host)
 
   log_line_prefix_escapes = %w(%m %u %d %p %r %a)
 
   log_line_prefix_escapes.each do |escape|
-    describe sql.query('SHOW log_line_prefix;', [PG_DB]) do
+    describe sql.query('SHOW log_line_prefix;', [pg_db]) do
       its('output') { should include escape }
     end
   end
 
-  describe sql.query('SHOW shared_preload_libraries;', [PG_DB]) do
+  describe sql.query('SHOW shared_preload_libraries;', [pg_db]) do
     its('output') { should include 'pgaudit' }
   end
 end

--- a/controls/V-73021.rb
+++ b/controls/V-73021.rb
@@ -19,22 +19,22 @@ Source: STIG.DOD.MIL
 uri: http://iase.disa.mil
 -----------------
 =end
-PG_DBA = attribute(
+pg_dba = attribute(
   'pg_dba',
   description: 'The postgres DBA user to access the test database',
 )
 
-PG_DBA_PASSWORD = attribute(
+pg_dba_password = attribute(
   'pg_dba_password',
   description: 'The password for the postgres DBA user',
 )
 
-PG_DB = attribute(
+pg_db = attribute(
   'pg_db',
   description: 'The database used for tests',
 )
 
-PG_HOST = attribute(
+pg_host = attribute(
   'pg_host',
   description: 'The hostname or IP address used to connect to the database',
 )
@@ -110,25 +110,25 @@ $ sudo systemctl reload postgresql-9.5
 # INITD SERVER ONLY
 $ sudo service postgresql-9.5 reload"
 
-  sql = postgres_session(PG_DBA, PG_DBA_PASSWORD, PG_HOST)
+  sql = postgres_session(pg_dba, pg_dba_password, pg_host)
 
-  describe sql.query('SHOW shared_preload_libraries;', [PG_DB]) do
+  describe sql.query('SHOW shared_preload_libraries;', [pg_db]) do
     its('output') { should include 'pgaudit' }
   end
 
   pgaudit_types = %w(ddl read role write)
 
   pgaudit_types.each do |type|
-    describe sql.query('SHOW pgaudit.log;', [PG_DB]) do
+    describe sql.query('SHOW pgaudit.log;', [pg_db]) do
       its('output') { should include type }
     end
   end
 
-  describe sql.query('SHOW log_connections;', [PG_DB]) do
+  describe sql.query('SHOW log_connections;', [pg_db]) do
     its('output') { should_not match /off|false/i }
   end
 
-  describe sql.query('SHOW log_disconnections;', [PG_DB]) do
+  describe sql.query('SHOW log_disconnections;', [pg_db]) do
     its('output') { should_not match /off|false/i }
   end
 end

--- a/controls/V-73025.rb
+++ b/controls/V-73025.rb
@@ -19,22 +19,22 @@ Source: STIG.DOD.MIL
 uri: http://iase.disa.mil
 -----------------
 =end
-PG_DBA = attribute(
+pg_dba = attribute(
   'pg_dba',
   description: 'The postgres DBA user to access the test database',
 )
 
-PG_DBA_PASSWORD = attribute(
+pg_dba_password = attribute(
   'pg_dba_password',
   description: 'The password for the postgres DBA user',
 )
 
-PG_DB = attribute(
+pg_db = attribute(
   'pg_db',
   description: 'The database used for tests',
 )
 
-PG_HOST = attribute(
+pg_host = attribute(
   'pg_host',
   description: 'The hostname or IP address used to connect to the database',
 )
@@ -167,9 +167,9 @@ week, month, year at the 0 minute mark.
 0 17 * * * postgres /usr/bin/psql -c \"REVOKE select(password) ON
 public.stig_audit_example FROM auditor;\""
 
-  sql = postgres_session(PG_DBA, PG_DBA_PASSWORD, PG_HOST)
+  sql = postgres_session(pg_dba, pg_dba_password, pg_host)
 
-  describe sql.query('SHOW shared_preload_libraries;', [PG_DB]) do
+  describe sql.query('SHOW shared_preload_libraries;', [pg_db]) do
     its('output') { should include 'pgaudit' }
   end
 end

--- a/controls/V-73029.rb
+++ b/controls/V-73029.rb
@@ -19,32 +19,32 @@ Source: STIG.DOD.MIL
 uri: http://iase.disa.mil
 -----------------
 =end
-PG_OWNER = attribute(
+pg_owner = attribute(
   'pg_owner',
   description: "The system user of the postgres process",
 )
 
-PG_DBA = attribute(
+pg_dba = attribute(
   'pg_dba',
   description: 'The postgres DBA user to access the test database',
 )
 
-PG_DBA_PASSWORD = attribute(
+pg_dba_password = attribute(
   'pg_dba_password',
   description: 'The password for the postgres DBA user',
 )
 
-PG_DB = attribute(
+pg_db = attribute(
   'pg_db',
   description: 'The database used for tests',
 )
 
-PG_HOST = attribute(
+pg_host = attribute(
   'pg_host',
   description: 'The hostname or IP address used to connect to the database',
 )
 
-PG_DATA_DIR = attribute(
+pg_data_dir = attribute(
   'pg_data_dir',
   description: 'The postgres data directory',
 )
@@ -121,12 +121,12 @@ $ sudo service postgresql-9.5 restart
 For more information on configuring PostgreSQL to use SSL, see supplementary content
 APPENDIX-G."
 
-  sql = postgres_session(PG_DBA, PG_DBA_PASSWORD, PG_HOST)
+  sql = postgres_session(pg_dba, pg_dba_password, pg_host)
 
   settings = %w(ssl_cert_file ssl_key_file ssl_ca_file ssl_crl_file)
 
   settings.each do |setting|
-    file_query = sql.query("SHOW #{setting};", [PG_DB])
+    file_query = sql.query("SHOW #{setting};", [pg_db])
     file = file_query.output
 
     if file.empty?
@@ -148,9 +148,9 @@ APPENDIX-G."
         ext = 'crl'
       end
 
-      file = "#{PG_DATA_DIR}/#{name}.#{ext}"
+      file = "#{pg_data_dir}/#{name}.#{ext}"
     elsif File.dirname(file) == '.'
-      file = "#{PG_DATA_DIR}/#{file}"
+      file = "#{pg_data_dir}/#{file}"
     end
 
     describe file(file) do
@@ -160,7 +160,7 @@ APPENDIX-G."
     directory = File.dirname(file)
 
     describe directory(directory) do
-      its('owner') { should match /root|#{PG_OWNER}/ }
+      its('owner') { should match /root|#{pg_owner}/ }
       its('mode') { should cmp '0700' }
     end
   end

--- a/controls/V-73031.rb
+++ b/controls/V-73031.rb
@@ -19,22 +19,22 @@ Source: STIG.DOD.MIL
 uri: http://iase.disa.mil
 -----------------
 =end
-PG_DBA = attribute(
+pg_dba = attribute(
   'pg_dba',
   description: 'The postgres DBA user to access the test database',
 )
 
-PG_DBA_PASSWORD = attribute(
+pg_dba_password = attribute(
   'pg_dba_password',
   description: 'The password for the postgres DBA user',
 )
 
-PG_DB = attribute(
+pg_db = attribute(
   'pg_db',
   description: 'The database used for tests',
 )
 
-PG_HOST = attribute(
+pg_host = attribute(
   'pg_host',
   description: 'The hostname or IP address used to connect to the database',
 )
@@ -81,13 +81,13 @@ documentation: http://www.postgresql.org/docs/current/static/ssl-tcp.html
 For more information on configuring PostgreSQL to use SSL, see supplementary content
 APPENDIX-G."
 
-  sql = postgres_session(PG_DBA, PG_DBA_PASSWORD, PG_HOST)
+  sql = postgres_session(pg_dba, pg_dba_password, pg_host)
 
-  describe sql.query('SHOW ssl_ca_file;', [PG_DB]) do
+  describe sql.query('SHOW ssl_ca_file;', [pg_db]) do
     its('output') { should_not eq '' }
   end
 
-  describe sql.query('SHOW ssl_cert_file;', [PG_DB]) do
+  describe sql.query('SHOW ssl_cert_file;', [pg_db]) do
     its('output') { should_not eq '' }
   end
 end

--- a/controls/V-73033.rb
+++ b/controls/V-73033.rb
@@ -19,22 +19,22 @@ Source: STIG.DOD.MIL
 uri: http://iase.disa.mil
 -----------------
 =end
-PG_DBA = attribute(
+pg_dba = attribute(
   'pg_dba',
   description: 'The postgres DBA user to access the test database',
 )
 
-PG_DBA_PASSWORD = attribute(
+pg_dba_password = attribute(
   'pg_dba_password',
   description: 'The password for the postgres DBA user',
 )
 
-PG_DB = attribute(
+pg_db = attribute(
   'pg_db',
   description: 'The database used for tests',
 )
 
-PG_HOST = attribute(
+pg_host = attribute(
   'pg_host',
   description: 'The hostname or IP address used to connect to the database',
 )
@@ -136,20 +136,20 @@ $ sudo systemctl reload postgresql-9.5
 # INITD SERVER ONLY
 $ sudo service postgresql-9.5 reload"
 
-  sql = postgres_session(PG_DBA, PG_DBA_PASSWORD, PG_HOST)
+  sql = postgres_session(pg_dba, pg_dba_password, pg_host)
 
   log_line_prefix_escapes = %w(%m %u %d %s)
   log_line_prefix_escapes.each do |escape|
-    describe sql.query('SHOW log_line_prefix;', [PG_DB]) do
+    describe sql.query('SHOW log_line_prefix;', [pg_db]) do
       its('output') { should include escape }
     end
   end
 
-  describe sql.query('SHOW log_connections;', [PG_DB]) do
+  describe sql.query('SHOW log_connections;', [pg_db]) do
     its('output') { should_not match /off|false/i }
   end
 
-  describe sql.query('SHOW log_disconnections;', [PG_DB]) do
+  describe sql.query('SHOW log_disconnections;', [pg_db]) do
     its('output') { should_not match /off|false/i }
   end
 end

--- a/controls/V-73035.rb
+++ b/controls/V-73035.rb
@@ -19,22 +19,22 @@ Source: STIG.DOD.MIL
 uri: http://iase.disa.mil
 -----------------
 =end
-PG_DBA = attribute(
+pg_dba = attribute(
   'pg_dba',
   description: 'The postgres DBA user to access the test database',
 )
 
-PG_DBA_PASSWORD = attribute(
+pg_dba_password = attribute(
   'pg_dba_password',
   description: 'The password for the postgres DBA user',
 )
 
-PG_DB = attribute(
+pg_db = attribute(
   'pg_db',
   description: 'The database used for tests',
 )
 
-PG_HOST = attribute(
+pg_host = attribute(
   'pg_host',
   description: 'The hostname or IP address used to connect to the database',
 )
@@ -94,11 +94,11 @@ With pgcrypto installed, it is possible to insert encrypted data into the databa
 INSERT INTO accounts(username, password) VALUES ('bob', crypt('a_secure_password',
 gen_salt('md5')));"
 
-  sql = postgres_session(PG_DBA, PG_DBA_PASSWORD, PG_HOST)
+  sql = postgres_session(pg_dba, pg_dba_password, pg_host)
 
   pgcrypto_sql = "SELECT * FROM pg_available_extensions where name='pgcrypto'"
 
-  describe sql.query(pgcrypto_sql, [PG_DB]) do
+  describe sql.query(pgcrypto_sql, [pg_db]) do
     its('output') { should_not eq '' }
   end
 end

--- a/controls/V-73037.rb
+++ b/controls/V-73037.rb
@@ -19,22 +19,22 @@ Source: STIG.DOD.MIL
 uri: http://iase.disa.mil
 -----------------
 =end
-PG_DBA = attribute(
+pg_dba = attribute(
   'pg_dba',
   description: 'The postgres DBA user to access the test database',
 )
 
-PG_DBA_PASSWORD = attribute(
+pg_dba_password = attribute(
   'pg_dba_password',
   description: 'The password for the postgres DBA user',
 )
 
-PG_DB = attribute(
+pg_db = attribute(
   'pg_db',
   description: 'The database used for tests',
 )
 
-PG_HOST = attribute(
+pg_host = attribute(
   'pg_host',
   description: 'The hostname or IP address used to connect to the database',
 )
@@ -105,21 +105,21 @@ $ sudo systemctl restart postgresql-9.5
 # INITD SERVER ONLY
 $ sudo service postgresql-9.5 restart"
 
-  sql = postgres_session(PG_DBA, PG_DBA_PASSWORD, PG_HOST)
+  sql = postgres_session(pg_dba, pg_dba_password, pg_host)
 
-  describe sql.query('SHOW tcp_keepalives_idle;', [PG_DB]) do
+  describe sql.query('SHOW tcp_keepalives_idle;', [pg_db]) do
     its('output') { should_not cmp 0 }
   end
 
-  describe sql.query('SHOW tcp_keepalives_interval;', [PG_DB]) do
+  describe sql.query('SHOW tcp_keepalives_interval;', [pg_db]) do
     its('output') { should_not cmp 0 }
   end
 
-  describe sql.query('SHOW tcp_keepalives_count;', [PG_DB]) do
+  describe sql.query('SHOW tcp_keepalives_count;', [pg_db]) do
     its('output') { should_not cmp 0 }
   end
 
-  describe sql.query('SHOW statement_timeout;', [PG_DB]) do
+  describe sql.query('SHOW statement_timeout;', [pg_db]) do
     its('output') { should_not cmp 0 }
   end
 end

--- a/controls/V-73041.rb
+++ b/controls/V-73041.rb
@@ -19,22 +19,22 @@ Source: STIG.DOD.MIL
 uri: http://iase.disa.mil
 -----------------
 =end
-PG_DBA = attribute(
+pg_dba = attribute(
   'pg_dba',
   description: 'The postgres DBA user to access the test database',
 )
 
-PG_DBA_PASSWORD = attribute(
+pg_dba_password = attribute(
   'pg_dba_password',
   description: 'The password for the postgres DBA user',
 )
 
-PG_DB = attribute(
+pg_db = attribute(
   'pg_db',
   description: 'The database used for tests',
 )
 
-PG_HOST = attribute(
+pg_host = attribute(
   'pg_host',
   description: 'The hostname or IP address used to connect to the database',
 )
@@ -98,12 +98,12 @@ $ sudo systemctl reload postgresql-9.5
 # INITD SERVER ONLY
 $ sudo service postgresql-9.5 reload"
 
-  sql = postgres_session(PG_DBA, PG_DBA_PASSWORD, PG_HOST)
+  sql = postgres_session(pg_dba, pg_dba_password, pg_host)
 
   log_line_prefix_escapes = ['%m']
 
   log_line_prefix_escapes.each do |escape|
-    describe sql.query('SHOW log_line_prefix;', [PG_DB]) do
+    describe sql.query('SHOW log_line_prefix;', [pg_db]) do
       its('output') { should include escape }
     end
   end

--- a/controls/V-73047.rb
+++ b/controls/V-73047.rb
@@ -19,22 +19,22 @@ Source: STIG.DOD.MIL
 uri: http://iase.disa.mil
 -----------------
 =end
-PG_DBA = attribute(
+pg_dba = attribute(
   'pg_dba',
   description: 'The postgres DBA user to access the test database',
 )
 
-PG_DBA_PASSWORD = attribute(
+pg_dba_password = attribute(
   'pg_dba_password',
   description: 'The password for the postgres DBA user',
 )
 
-PG_DB = attribute(
+pg_db = attribute(
   'pg_db',
   description: 'The database used for tests',
 )
 
-PG_HOST = attribute(
+pg_host = attribute(
   'pg_host',
   description: 'The hostname or IP address used to connect to the database',
 )
@@ -93,9 +93,9 @@ APPENDIX-G.
 For further SSL configurations, see the official documentation:
 https://www.postgresql.org/docs/current/static/ssl-tcp.html"
 
-  sql = postgres_session(PG_DBA, PG_DBA_PASSWORD, PG_HOST)
+  sql = postgres_session(pg_dba, pg_dba_password, pg_host)
 
-  describe sql.query('SHOW ssl;', [PG_DB]) do
+  describe sql.query('SHOW ssl;', [pg_db]) do
     its('output') { should match /on|true/i }
   end
 end

--- a/controls/V-73049.rb
+++ b/controls/V-73049.rb
@@ -19,48 +19,48 @@ Source: STIG.DOD.MIL
 uri: http://iase.disa.mil
 -----------------
 =end
-PG_OWNER = attribute(
+pg_owner = attribute(
   'pg_owner',
   description: "The system user of the postgres process",
 )
 
-PG_DBA = attribute(
+pg_dba = attribute(
   'pg_dba',
   description: 'The postgres DBA user to access the test database',
 )
 
-PG_DBA_PASSWORD = attribute(
+pg_dba_password = attribute(
   'pg_dba_password',
   description: 'The password for the postgres DBA user',
 )
 
-PG_DB = attribute(
+pg_db = attribute(
   'pg_db',
   description: 'The database used for tests',
 )
 
-PG_HOST = attribute(
+pg_host = attribute(
   'pg_host',
   description: 'The hostname or IP address used to connect to the database',
 )
 
-PG_USERS = attribute(
+pg_users = attribute(
   'pg_users',
   description: 'Authorized accounts',
   default: 'postgres',
 )
 
-PG_DATA_DIR = attribute(
+pg_data_dir = attribute(
   'pg_data_dir',
   description: 'The postgres data directory',
 )
 
-PG_HBA_CONF_FILE = attribute(
+pg_hba_conf_file = attribute(
   'pg_hba_conf_file',
   description: 'The postgres hba configuration file',
 )
 
-PG_REPLICAS = attribute(
+pg_replicas = attribute(
   'pg_replicas',
   description: 'List of postgres replicas in CIDR notation',
 )
@@ -143,29 +143,29 @@ host test_db bob 192.168.0.0/16 md5
 For more information on pg_hba.conf, see the official documentation:
 https://www.postgresql.org/docs/current/static/auth-pg-hba-conf.html"
 
-  sql = postgres_session(PG_DBA, PG_DBA_PASSWORD, PG_HOST)
+  sql = postgres_session(pg_dba, pg_dba_password, pg_host)
 
-  authorized_roles = PG_USERS
+  authorized_roles = pg_users
 
   roles_sql = 'SELECT r.rolname FROM pg_catalog.pg_roles r;'
 
-  describe sql.query(roles_sql, [PG_DB]) do
+  describe sql.query(roles_sql, [pg_db]) do
     its('lines.sort') { should cmp authorized_roles.sort }
   end
 
-  describe postgres_hba_conf(PG_HBA_CONF_FILE).where { type == 'local' } do
-    its('user.uniq') { should cmp PG_OWNER }
+  describe postgres_hba_conf(pg_hba_conf_file).where { type == 'local' } do
+    its('user.uniq') { should cmp pg_owner }
     its('auth_method.uniq') { should_not include 'trust'}
   end
 
-  describe postgres_hba_conf(PG_HBA_CONF_FILE).where { database == 'replication' } do
+  describe postgres_hba_conf(pg_hba_conf_file).where { database == 'replication' } do
     its('type.uniq') { should cmp 'host' }
-    its('address.uniq.sort') { should cmp PG_REPLICAS.sort }
+    its('address.uniq.sort') { should cmp pg_replicas.sort }
     its('user.uniq') { should cmp 'replication' }
     its('auth_method.uniq') { should cmp 'md5' }
   end
 
-  describe postgres_hba_conf(PG_HBA_CONF_FILE).where { type == 'host' } do
+  describe postgres_hba_conf(pg_hba_conf_file).where { type == 'host' } do
     its('auth_method.uniq') { should cmp 'md5'}
   end
 end

--- a/controls/V-73061.rb
+++ b/controls/V-73061.rb
@@ -19,32 +19,32 @@ Source: STIG.DOD.MIL
 uri: http://iase.disa.mil
 -----------------
 =end
-PG_DBA = attribute(
+pg_dba = attribute(
   'pg_dba',
   description: 'The postgres DBA user to access the test database',
 )
 
-PG_DBA_PASSWORD = attribute(
+pg_dba_password = attribute(
   'pg_dba_password',
   description: 'The password for the postgres DBA user',
 )
 
-PG_DB = attribute(
+pg_db = attribute(
   'pg_db',
   description: 'The database used for tests',
 )
 
-PG_HOST = attribute(
+pg_host = attribute(
   'pg_host',
   description: 'The hostname or IP address used to connect to the database',
 )
 
-PG_DATA_DIR = attribute(
+pg_data_dir = attribute(
   'pg_data_dir',
   description: 'The postgres data directory',
 )
 
-PG_CONF_FILE = attribute(
+pg_conf_file = attribute(
   'pg_conf_file',
   description: 'The postgres configuration file',
 )
@@ -119,18 +119,18 @@ control "V-73061" do
       $ chown postgres:postgres ${PGDATA?}/*.conf
       $ chmod 0600 ${PGDATA?}/*.conf"
 
-  describe file(PG_CONF_FILE) do
+  describe file(pg_conf_file) do
     it { should be_file }
     its('mode') { should cmp '0600' }
   end
 
-  sql = postgres_session(PG_DBA, PG_DBA_PASSWORD, PG_HOST)
+  sql = postgres_session(pg_dba, pg_dba_password, pg_host)
 
-  log_destination_query = sql.query('SHOW log_destination;', [PG_DB])
+  log_destination_query = sql.query('SHOW log_destination;', [pg_db])
   log_destination = log_destination_query.output
 
   if log_destination =~ /stderr/i
-    describe sql.query('SHOW log_file_mode;', [PG_DB]) do
+    describe sql.query('SHOW log_file_mode;', [pg_db]) do
       its('output') { should cmp '0600' }
     end
   end

--- a/controls/V-73063.rb
+++ b/controls/V-73063.rb
@@ -19,67 +19,67 @@ Source: STIG.DOD.MIL
 uri: http://iase.disa.mil
 -----------------
 =end
-PG_OWNER = attribute(
+pg_owner = attribute(
   'pg_owner',
   description: "The system user of the postgres process",
 )
 
-PG_GROUP = attribute(
+pg_group = attribute(
   'pg_group',
   description: "The system group of the postgres process",
 )
 
-PG_DBA = attribute(
+pg_dba = attribute(
   'pg_dba',
   description: 'The postgres DBA user to access the test database',
 )
 
-PG_DBA_PASSWORD = attribute(
+pg_dba_password = attribute(
   'pg_dba_password',
   description: 'The password for the postgres DBA user',
 )
 
-PG_DB = attribute(
+pg_db = attribute(
   'pg_db',
   description: 'The database used for tests',
 )
 
-PG_HOST = attribute(
+pg_host = attribute(
   'pg_host',
   description: 'The hostname or IP address used to connect to the database',
 )
 
-PG_PORT = attribute(
+pg_port = attribute(
   'pg_port',
   description: 'The port used to connect to the database',
 )
 
-PG_DATA_DIR = attribute(
+pg_data_dir = attribute(
   'pg_data_dir',
   description: 'The postgres data directory',
 )
 
-PG_CONF_FILE = attribute(
+pg_conf_file = attribute(
   'pg_conf_file',
   description: 'The postgres configuration file',
 )
 
-PG_USER_DEFINED_CONF = attribute(
+pg_user_defined_conf = attribute(
   'pg_user_defined_conf',
   description: 'An additional postgres configuration file used to override default values',
 )
 
-PG_SUPERUSERS = attribute(
+pg_superusers = attribute(
   'pg_superusers',
   description: 'Authorized superuser accounts',
 )
 
-PG_VERSION = attribute(
+pg_version = attribute(
   'pg_version',
   description: "The version of postgres",
 )
 
-PG_SHARED_DIRS = attribute(
+pg_shared_dirs = attribute(
   'pg_shared_dirs',
   description: 'defines the locations of the postgresql shared library directories',
 )

--- a/controls/V-73065.rb
+++ b/controls/V-73065.rb
@@ -19,22 +19,22 @@ Source: STIG.DOD.MIL
 uri: http://iase.disa.mil
 -----------------
 =end
-PG_DBA = attribute(
+pg_dba = attribute(
   'pg_dba',
   description: 'The postgres DBA user to access the test database',
 )
 
-PG_DBA_PASSWORD = attribute(
+pg_dba_password = attribute(
   'pg_dba_password',
   description: 'The password for the postgres DBA user',
 )
 
-PG_DB = attribute(
+pg_db = attribute(
   'pg_db',
   description: 'The database used for tests',
 )
 
-PG_HOST = attribute(
+pg_host = attribute(
   'pg_host',
   description: 'The hostname or IP address used to connect to the database',
 )
@@ -102,16 +102,16 @@ control "V-73065" do
       # INITD SERVER ONLY
       $ sudo service postgresql-9.5 reload"
 
-  sql = postgres_session(PG_DBA, PG_DBA_PASSWORD, PG_HOST)
+  sql = postgres_session(pg_dba, pg_dba_password, pg_host)
 
-  describe sql.query('SHOW shared_preload_libraries;', [PG_DB]) do
+  describe sql.query('SHOW shared_preload_libraries;', [pg_db]) do
     its('output') { should include 'pgaudit' }
   end
 
   pgaudit_types = %w(ddl read role write)
 
   pgaudit_types.each do |type|
-    describe sql.query('SHOW pgaudit.log;', [PG_DB]) do
+    describe sql.query('SHOW pgaudit.log;', [pg_db]) do
       its('output') { should include type }
     end
   end

--- a/controls/V-73067.rb
+++ b/controls/V-73067.rb
@@ -19,22 +19,22 @@ Source: STIG.DOD.MIL
 uri: http://iase.disa.mil
 -----------------
 =end
-PG_DBA = attribute(
+pg_dba = attribute(
   'pg_dba',
   description: 'The postgres DBA user to access the test database',
 )
 
-PG_DBA_PASSWORD = attribute(
+pg_dba_password = attribute(
   'pg_dba_password',
   description: 'The password for the postgres DBA user',
 )
 
-PG_DB = attribute(
+pg_db = attribute(
   'pg_db',
   description: 'The database used for tests',
 )
 
-PG_HOST = attribute(
+pg_host = attribute(
   'pg_host',
   description: 'The hostname or IP address used to connect to the database',
 )
@@ -115,16 +115,16 @@ control "V-73067" do
       # INITD SERVER ONLY
       $ sudo service postgresql-9.5 reload"
 
-  sql = postgres_session(PG_DBA, PG_DBA_PASSWORD, PG_HOST)
+  sql = postgres_session(pg_dba, pg_dba_password, pg_host)
 
-  describe sql.query('SHOW shared_preload_libraries;', [PG_DB]) do
+  describe sql.query('SHOW shared_preload_libraries;', [pg_db]) do
     its('output') { should include 'pgaudit' }
   end
 
   pgaudit_types = ['read', 'write']
 
   pgaudit_types.each do |type|
-    describe sql.query('SHOW pgaudit.log;', [PG_DB]) do
+    describe sql.query('SHOW pgaudit.log;', [pg_db]) do
       its('output') { should include type }
     end
   end

--- a/controls/V-73069.rb
+++ b/controls/V-73069.rb
@@ -19,22 +19,22 @@ Source: STIG.DOD.MIL
 uri: http://iase.disa.mil
 -----------------
 =end
-PG_DBA = attribute(
+pg_dba = attribute(
   'pg_dba',
   description: 'The postgres DBA user to access the test database',
 )
 
-PG_DBA_PASSWORD = attribute(
+pg_dba_password = attribute(
   'pg_dba_password',
   description: 'The password for the postgres DBA user',
 )
 
-PG_DB = attribute(
+pg_db = attribute(
   'pg_db',
   description: 'The database used for tests',
 )
 
-PG_HOST = attribute(
+pg_host = attribute(
   'pg_host',
   description: 'The hostname or IP address used to connect to the database',
 )
@@ -109,17 +109,17 @@ control "V-73069" do
       # INITD SERVER ONLY
       $ sudo service postgresql-9.5 reload"
 
-  sql = postgres_session(PG_DBA, PG_DBA_PASSWORD, PG_HOST)
+  sql = postgres_session(pg_dba, pg_dba_password, pg_host)
 
-  describe sql.query('SHOW shared_preload_libraries;', [PG_DB]) do
+  describe sql.query('SHOW shared_preload_libraries;', [pg_db]) do
     its('output') { should include 'pgaudit' }
   end
 
-  describe sql.query('SHOW log_connections;', [PG_DB]) do
+  describe sql.query('SHOW log_connections;', [pg_db]) do
     its('output') { should match /on|true/i }
   end
 
-  describe sql.query('SHOW log_disconnections;', [PG_DB]) do
+  describe sql.query('SHOW log_disconnections;', [pg_db]) do
     its('output') { should match /on|true/i }
   end
 end

--- a/controls/V-73123.rb
+++ b/controls/V-73123.rb
@@ -19,22 +19,22 @@ Source: STIG.DOD.MIL
 uri: http://iase.disa.mil
 -----------------
 =end
-PG_DBA = attribute(
+pg_dba = attribute(
   'pg_dba',
   description: 'The postgres DBA user to access the test database',
 )
 
-PG_DBA_PASSWORD = attribute(
+pg_dba_password = attribute(
   'pg_dba_password',
   description: 'The password for the postgres DBA user',
 )
 
-PG_DB = attribute(
+pg_db = attribute(
   'pg_db',
   description: 'The database used for tests',
 )
 
-PG_HOST = attribute(
+pg_host = attribute(
   'pg_host',
   description: 'The hostname or IP address used to connect to the database',
 )
@@ -105,12 +105,12 @@ control "V-73123" do
   # INITD SERVER ONLY
   $ sudo service postgresql-9.5 reload"
 
-  sql = postgres_session(PG_DBA, PG_DBA_PASSWORD, PG_HOST)
+  sql = postgres_session(pg_dba, pg_dba_password, pg_host)
 
   log_line_prefix_escapes = %w(%m %u %d %s)
 
   log_line_prefix_escapes.each do |escape|
-    describe sql.query('SHOW log_line_prefix;', [PG_DB]) do
+    describe sql.query('SHOW log_line_prefix;', [pg_db]) do
       its('output') { should include escape }
     end
   end


### PR DESCRIPTION
Using this repo as a dependency prints Ruby constant warnings on the console to stderr.  Because the top level of each file is executed in the same Ruby process, redefining globals.

Example:
```
warning: previous definition of PG_HOST was here
```

I mass renamed all constants to normal variables which are still in scope.  I did a single manual test  to exercise a random V number.  The warning disappeared and the variable value was used as before.  I don't have a regression test.  Please review and let me know what you think.